### PR TITLE
Adds support for non-interactive nodes on KmapsRelationsTree

### DIFF
--- a/app/views/features/_menu.html.erb
+++ b/app/views/features/_menu.html.erb
@@ -137,6 +137,8 @@
     language: $('#menu_js_data').data('language'),
     featuresPath: $('#menu_js_data').data('featuresPath'),
     sortBy: 'position_i+ASC',
+    extraFields: ['associated_subject_ids'],
+    nodeMarkerPredicates: [{field: 'associated_subject_ids', value: 9315, operation: '!includes', mark: 'nonInteractiveNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
   });
 
   var session_search = Cookies.getJSON('search_<%= Feature.uid_prefix %>');


### PR DESCRIPTION
**Jira Issue:** MANU-5652

**Changes proposed in this pull request:**

 + Add support for non-interactive nodes on the flyout tree.

**Details of the implementation:**
Now nodes that are non-interactive only open and close the node instead
of opening the terms page. This is dependant on the new implementation
of KmapsRelationsTree plugin in kmaps_engine.

Related to this pull request on kmaps_engine: https://github.com/shanti-uva/kmaps_engine/pull/35
