### PR TITLE
Add subject term association editorial interface - MANU-6071

### DIFF
--- a/app/assets/javascripts/terms_engine/subject_term_associations_admin.js
+++ b/app/assets/javascripts/terms_engine/subject_term_associations_admin.js
@@ -1,0 +1,130 @@
+$(document).ready(function() {
+  $("#branch_name").kmapsSimpleTypeahead({
+    solr_index: $('#subject_term_association_js_data').data('termIndex'),
+    domain: $('#subject_term_association_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+          //The return value includes the domain, i.e. subjects-653
+          $("#branch_id").val(sel.doc.id.replace($('#subject_term_association_js_data').data('domain')+'-',''));
+          $("#subject_name").kmapsSimpleTypeahead('updateAdditionalFilters',["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:**/"+$('#branch_id').val()+"/*"]);
+      });
+  $("#subject_name").kmapsSimpleTypeahead({
+    solr_index: $('#subject_term_association_js_data').data('termIndex'),
+    domain: $('#subject_term_association_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    additional_filters: ["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:*/"+$('#branch_id').val()+"/*"],
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+        //The return value includes the domain, i.e. subjects-653
+        $("#subject_id").val(sel.doc.id.replace($('#subject_term_association_js_data').data('domain')+'-',''));
+        }
+      );
+
+   var selectAncestorSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#subject_term_association_js_data').data('termIndex'),
+    assetIndex: $('#subject_term_association_js_data').data('assetIndex'),
+    featureId: $('#subject_term_association_js_data').data('featureId'),
+    domain: $('#subject_term_association_js_data').data('domain'),
+    perspective: $('#subject_term_association_js_data').data('perspective'),
+    tree: $('#subject_term_association_js_data').data('tree'), //places
+    featuresPath: $('#subject_term_association_js_data').data('featuresPath'),
+  });
+  $("#branch_tree_container").kmapsRelationsTree({
+    featureId: $('#subject_term_association_js_data').data('featureId'),
+    featuresPath: $('#subject_term_association_js_data').data('featuresPath'),
+    termIndex: $('#subject_term_association_js_data').data('termIndex'),
+    assetIndex: $('#subject_term_association_js_data').data('assetIndex'),
+    perspective: $('#subject_term_association_js_data').data('perspective'),
+    tree: $('#subject_term_association_js_data').data('tree'), //places
+    domain: $('#subject_term_association_js_data').data('domain'), //places
+    extraFields: ["header"],
+    descendants: false,
+    descendantsFullDetail: false,
+    displayPopup: false,
+    solrUtils: selectAncestorSolrUtils,
+    nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+  });
+  $("#branch_tree_container").on("fancytreeactivate", function(event, data){
+    $("#branch_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+    $("#branch_id").val(data.node.key.replace($('#subject_term_association_js_data').data('domain')+'-',''));
+    $("#subject_name").kmapsSimpleTypeahead('updateAdditionalFilters',["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:**/"+$('#branch_id').val()+"/*"]);
+
+    if ($("#subject_tree_container")) {
+      $("#subject_tree_container").remove();
+      $("#subject_container").append('<div id="subject_tree_container"></div>');
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+
+    }
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#subject_term_association_js_data').data('domain')+"-"+$('#branch_id').val(),
+      featuresPath: $('#subject_term_association_js_data').data('featuresPath'),
+      termIndex: $('#subject_term_association_js_data').data('termIndex'),
+      assetIndex: $('#subject_term_association_js_data').data('assetIndex'),
+      perspective: $('#subject_term_association_js_data').data('perspective'),
+      tree: $('#subject_term_association_js_data').data('tree'), //places
+      domain: $('#subject_term_association_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#subject_term_association_js_data').data('domain')+'-',''));
+    });
+  });
+  if($("#branch_id").val() != '') {
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#subject_term_association_js_data').data('domain')+"-"+$('#branch_id').val(),
+      featuresPath: $('#subject_term_association_js_data').data('featuresPath'),
+      termIndex: $('#subject_term_association_js_data').data('termIndex'),
+      assetIndex: $('#subject_term_association_js_data').data('assetIndex'),
+      perspective: $('#subject_term_association_js_data').data('perspective'),
+      tree: $('#subject_term_association_js_data').data('tree'), //places
+      domain: $('#subject_term_association_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#subject_term_association_js_data').data('domain')+'-',''));
+    });
+  }
+
+  $("#subject_tree_container").hide();
+  $("#branch_tree_container").hide();
+  $("#js-expand-branch-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-branch-tree").text().includes('hide')){
+      $("#js-expand-branch-tree").text("Or click here to view branch hierarchy");
+    } else {
+      $("#js-expand-branch-tree").text("Or click here to hide branch hierarchy");
+    }
+    $("#branch_tree_container").toggle();
+  });
+  $("#js-expand-subject-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-subject-tree").text().includes('hide')){
+      $("#js-expand-subject-tree").text("Or click here to view subject hierarchy");
+    } else {
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+    }
+    $("#subject_tree_container").toggle();
+  });
+
+});

--- a/app/assets/stylesheets/terms_engine/application.css
+++ b/app/assets/stylesheets/terms_engine/application.css
@@ -11,6 +11,7 @@
  *= require_self
  *= require mandala_terms/shanti-main-terms
  *= require terms_engine/recordings
+ *= require terms_engine/subject_term_associations
  */
 
 body.page-terms .content-section {

--- a/app/assets/stylesheets/terms_engine/subject_term_associations.css
+++ b/app/assets/stylesheets/terms_engine/subject_term_associations.css
@@ -1,0 +1,9 @@
+.subject-term-associations-form-fields input#branch_name, input#subject_name {
+    padding-left: 0;
+}
+.subject-term-associations-form-fields .row, .twitter-typeahead {
+ margin: 0 0 0.2rem 1rem;
+}
+.subject-term-associations-form-fields .row {
+  padding-top: 10px;
+}

--- a/app/controllers/admin/subject_term_associations_controller.rb
+++ b/app/controllers/admin/subject_term_associations_controller.rb
@@ -1,0 +1,19 @@
+class Admin::SubjectTermAssociationsController < AclController
+  include KmapsEngine::ResourceObjectAuthentication
+  resource_controller
+
+  belongs_to :feature
+
+  new_action.wants.html do
+    if params[:branch_id]
+      object.branch_id = params[:branch_id]
+    end
+  end
+
+  protected
+
+  # Only allow a trusted parameter "white list" through.
+  def subject_term_association_params
+    params.require(:subject_term_association).permit(:feature_id, :subject_id, :branch_id)
+  end
+end

--- a/app/helpers/admin/subject_term_associations_helper.rb
+++ b/app/helpers/admin/subject_term_associations_helper.rb
@@ -1,0 +1,9 @@
+module Admin::SubjectTermAssociationsHelper
+  def new_subject_term_associations_links
+    SubjectTermAssociation.select('branch_id').distinct.sort_by {|a| a.branch['header']}.map do |a|
+      link_to "#{a.branch['header']} association", 
+        new_admin_feature_subject_term_association_path(object) +
+        "?branch_id=#{a.branch_id}"
+    end.join(" | ").html_safe
+  end
+end

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -178,5 +178,20 @@
     </div> <!-- END panel-body -->
   </div> <!-- END collapseTen -->
 </section>
+<section class="panel panel-default">
+  <div class="panel-heading">
+    <h6><a href="#collapseTwelve" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= SubjectTermAssociation.model_name.human(count: :many).titleize.s %></a></h6>
+  </div>
+  <div id="collapseTwelve" class="panel-collapse collapse">
+    <div class="panel-body">
+      <%=       highlighted_new_item_link [object, :subject_term_association] %>
+      <br>
+      <h6>Create Specific Association:</h6>
+      <%= new_subject_term_associations_links %>
+      <br class="clear"/>
+      <%=       render :partial => 'admin/subject_term_associations/list', :locals => { :list => object.subject_term_associations } %>
+    </div> <!-- END panel-body -->
+  </div> <!-- END collapseTen -->
+</section>
   </div> <!-- END accordion -->
 </div> <!-- END featureShow -->

--- a/app/views/admin/subject_term_associations/_form_fields.html.erb
+++ b/app/views/admin/subject_term_associations/_form_fields.html.erb
@@ -1,0 +1,47 @@
+<div class="subject-term-associations-form-fields">
+<% if object.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(object.errors.count, "error") %> prohibited this subject term association from being saved:</h2>
+
+      <ul>
+        <% object.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+<% end %>
+<fieldset>
+  <legend><%= ts(:for, what: t('information.general'), whom: SubjectTermAssociation.model_name.human.titleize) %></legend>
+  <div class="row">
+    <%= form.label :branch_name, ts(:branch, count: 1).titleize %>
+    <br/>
+    <br/>
+    <%= form.hidden_field :branch_id, id: :branch_id %>
+    <p>Search by name</p>
+    <%= text_field_tag :branch_name, :post, { placeholder: 'Search by branch name', value: object.branch.blank? ? '' : object.branch['header'] } %>
+    <a href="#" id="js-expand-branch-tree">Or click here to view branch hierarchy</a>
+     <div id="branch_tree_container"></div>
+  </div>
+  <div class="row" id="subject_container">
+    <%= form.label :subject_name, SubjectsIntegration::Feature.human_name(count: 1).titleize %>
+    <br/>
+    <br/>
+    <%= form.hidden_field :subject_id, id: :subject_id %>
+    <p>Search by name</p>
+    <%= text_field_tag :subject_name, :post, { placeholder: 'Search by subject name', value: object.subject.blank? ? '' : object.subject['header'] } %>
+    <a href="#" id="js-expand-subject-tree">Or click here to view subject hierarchy</a>
+     <div id="subject_tree_container"></div>
+  </div>
+</fieldset>
+</div> <!-- END - subject-term-associations-form-fields -->
+<%= content_tag :div, "", id: 'subject_term_association_js_data', data: {
+ term_index: Feature.config.url,
+ asset_index: Flare.config.asset_url,
+ feature_id: "",
+ domain: "subjects",
+ perspective: "gen",
+ tree: "subjects",
+ features_path: "#{new_admin_feature_path}?parent_id=%%ID%%",
+ mandala_path: "https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs",
+} %>
+<%= javascript_include_tag 'terms_engine/subject_term_associations_admin' %>

--- a/app/views/admin/subject_term_associations/_list.html.erb
+++ b/app/views/admin/subject_term_associations/_list.html.erb
@@ -1,0 +1,22 @@
+<% if list.empty? %>
+<%=  empty_collection_message %>
+<% else %>
+   <table class="listGrid">
+     <tr>
+       <th class="listActionsCol"></th>
+       <th><%= ts('branch', count: 1) %></th>
+       <th><%= ts('subject', count: 1) %></th>
+     </tr>
+<%   list.each do |item| %>
+     <tr>
+       <td class="centerText">
+<%=      list_actions_for_item(item, :delete_path => admin_feature_subject_term_association_path(item.feature, item),
+         :edit_path => edit_admin_feature_subject_term_association_path(item.feature, item),
+         :view_path => admin_feature_subject_term_association_path(item.feature, item)) %>
+       </td>
+       <td><%= item.branch['header'].s %></td>
+       <td><%= item.subject['header'].s %></td>
+     </tr>
+<%   end %>
+   </table>
+<% end %>

--- a/app/views/admin/subject_term_associations/edit.html.erb
+++ b/app/views/admin/subject_term_associations/edit.html.erb
@@ -1,0 +1,17 @@
+<% add_breadcrumb_item feature_link(object.feature)
+   add_breadcrumb_item link_to 'subject term association', admin_feature_subject_term_associations_path(object.feature)
+   add_breadcrumb_item object.id %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6>Editing <%= SubjectTermAssociation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+    <%= form_with(model: [:admin, object.feature, object], local: true) do |form| %>
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <div class="actions">
+      <%=  link_to ts('cancel.this'), admin_feature_path(object.feature) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
+      </div>
+    <% end %>
+  </div> <!-- END panel-body -->
+</section> <!-- END panel -->

--- a/app/views/admin/subject_term_associations/index.html.erb
+++ b/app/views/admin/subject_term_associations/index.html.erb
@@ -1,0 +1,9 @@
+<% add_breadcrumb_item feature_link(parent_object) %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6><%= SubjectTermAssociation.model_name.human.pluralize.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+<%=       render :partial => 'admin/subject_term_associations/list', :locals => { :list => parent_object.subject_term_associations } %>
+  </div> <!-- END panel-body -->
+</section> <!-- END panel -->

--- a/app/views/admin/subject_term_associations/new.html.erb
+++ b/app/views/admin/subject_term_associations/new.html.erb
@@ -1,0 +1,18 @@
+<% add_breadcrumb_item feature_link(object.feature)
+   add_breadcrumb_item link_to 'subject term association', admin_feature_subject_term_associations_path(object.feature)
+%>
+<div>
+  <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: SubjectTermAssociation.model_name.human.titleize)), whom: "#{Feature.model_name.human.titleize} #{parent_object}" %></h1>
+</div>
+<%= form_with(model: [:admin, object.feature, object], local: true) do |form| %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6><%= SubjectTermAssociation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <%=  link_to ts('cancel.this'), admin_feature_path(object.feature) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->
+<% end %>

--- a/app/views/admin/subject_term_associations/show.html.erb
+++ b/app/views/admin/subject_term_associations/show.html.erb
@@ -1,0 +1,27 @@
+<% add_breadcrumb_item feature_link(object.feature)
+   add_breadcrumb_item link_to 'subject term associations', admin_feature_subject_term_associations_path
+   add_breadcrumb_item object.id %>
+ <section class="panel panel-content">
+   <div class="panel-heading">
+     <h6><%= SubjectTermAssociation.model_name.human.titleize.s %></h6>
+   </div>
+     <div class="panel-body">
+    <p id="notice"><%= notice %></p>
+
+    <p>
+    <strong><%= ts('branch', count: 1)%>:</strong>
+    <%= object.branch['header'] %>
+    </p>
+    <p>
+    <strong><%= ts('subject', count: 1)%>:</strong>
+    <%= object.subject['header'] %>
+    </p>
+
+     <%= link_to ts('Edit'), edit_admin_feature_subject_term_association_path(object.feature, object), class: 'btn btn-primary form-submit' %> |
+     <% if !defined?(parent_object) %>
+       <%= link_to 'Back', admin_path  %>
+     <% else %>
+       <%=  link_to ts('cancel.this'), admin_feature_path(object.feature), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+     <% end %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,3 @@
 Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'stylesheets').to_s
 Rails.application.config.assets.paths << Rails.root.join('assets', 'stylesheets', 'terms_engine').to_s
-Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js'])
-Rails.application.config.assets.precompile.concat(['terms_engine/recordings_admin.js'])
+Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js','terms_engine/recordings_admin.js','terms_engine/subject_term_associations_admin.js'])

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -3,6 +3,9 @@ en:
     app:
         short: 'Terms'
         this: 'Knowledge Maps of Terms'
+    branch:
+      one: 'Branch'
+      other: 'Branches'
     dialect:
       one: 'dialect'
       other: 'dialects'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       resources :definitions do #, only: [:index, :show]
         get :locate_for_relation, on: :member
       end
+      resources :subject_term_associations
     end
   end
   resources :passages, only: [:show] do

--- a/lib/terms_engine/version.rb
+++ b/lib/terms_engine/version.rb
@@ -1,3 +1,3 @@
 module TermsEngine
-  VERSION = '0.4.6'
+  VERSION = '0.4.7'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6071

**Changes proposed in this pull request:**

 + Add editorial interface for subject term association.

**Details of the implementation:**

Aside from adding the editorial interface for CRUD of Subject Term Association, added list of already used branches on existing subject term association. 