### PR TITLE
Added new workflow for creating new term for tibetan perspective - MANU-6072

### DIFF
--- a/app/services/terms_service.rb
+++ b/app/services/terms_service.rb
@@ -52,6 +52,23 @@ class TermsService
     sorted = sorted_terms
     sorted.each_index { |i| sorted[i].update_attribute(:position, i+1) }
   end
+
+  def self.get_wylie(name)
+    response = Faraday.get "http://www.thlib.org/cgi-bin/thl/lbow/wylie.pl", { plain: :true, conversion: :uni2wy, input: name.tibetan_cleanup }
+    if response.body == "[#{name}]"
+      return nil
+    else
+      return response.body
+    end
+  end
+  def self.get_phonetic(name)
+    response = Faraday.get "http://www.thlib.org/cgi-bin/thl/lbow/phonetics.pl", { plain: :true, input: name.tibetan_cleanup }
+    if response.body.include? "\n---\n"
+      return nil
+    else
+      return response.body
+    end
+  end
   
   def self.add_term(level_subject_id, tibetan = nil, wylie = nil, phonetic = nil)
     f = Feature.search_by_phoneme(tibetan || wylie, level_subject_id)

--- a/app/views/admin/features/new.html.erb
+++ b/app/views/admin/features/new.html.erb
@@ -1,0 +1,70 @@
+<%  add_breadcrumb_items ts('new.this') %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6><%= "#{Feature.model_name.human.titleize.s}" %></h6>
+  </div>
+  <div class="panel-body">
+    <% url = admin_features_path
+    if current_perspective.code == "tib.alpha"
+      url = create_tibetan_term_admin_features_path
+    end %>
+    <%= form_with(model: object, url: url, local: true) do |form| %>
+      <div class="term-form-fields">
+        <% if object.errors.any? %>
+          <div id="error_explanation">
+            <h2><%= pluralize(object.errors.count, "error") %> prohibited this term from being saved:</h2>
+            <ul>
+              <% object.errors.full_messages.each do |message| %>
+                <% if message == t('feature.errors.term_exists') %>
+                  <li><%= message %> <%= highlighted_new_item_link [@current_term, :definition] %> for <%= @name %></li>
+                <% else %>
+                  <li><%= message %></li>
+                <% end %>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <% if current_perspective.code == "tib.alpha" %>
+          <fieldset>
+            <legend><%= ts(:for, what: t('information.general'), whom: Feature.model_name.human.titleize) %></legend>
+            <div class="row">
+              <%= form.label :term_name, Feature.model_name.human.titleize %>
+              <br/>
+              <br/>
+              <%= text_field_tag :term_name, :post, { placeholder: t('snippet.feature.name.unicode_insert_request'), value: @name, id: :term_name } %>
+              <%=  link_to ts('cancel.this'), admin_features_path(object) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+              <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+            </div>
+          </fieldset>
+        <% else %>
+          <%=   render partial: 'form_fields', locals: {f: form} %>
+          <%=   fields_for @name do |name_fields| %>
+            <%=     render partial: 'admin/feature_names/form_fields', locals: {f: name_fields} %>
+          <%    end %>
+          <%=   fields_for @relation do |relation_fields| %>
+            <fieldset>
+              <legend><%= ts(:for, what: t('relat.ion.this.one').titleize, whom: fname_labels(@parent)) %></legend>
+              <%=     relation_fields.hidden_field :parent_node_id %>
+              <div class="row">
+                <%=       relation_fields.label :feature_relation_type_id, FeatureRelationType.model_name.human.titleize.s %>
+                <%=       relation_fields.select :feature_relation_type_id, FeatureRelationType.order(:asymmetric_label).collect { |t| [ t.is_symmetric? ? t.label : t.asymmetric_label, t.id ] }, {}, class: 'form-control form-select ss-select selectpicker' %>
+                <%=       fname_labels(@parent) %>
+              </div>
+              <div class="row">
+                <%=       relation_fields.label :perspective_id, Perspective.model_name.human.titleize.s %>
+                <%=       relation_fields.collection_select :perspective_id, @perspectives, :id, :name, {}, class: 'form-control form-select ss-select selectpicker' %>
+              </div>
+            </fieldset>
+          <% end %> <!-- END fields_for @relation -->
+          <%=  link_to ts('cancel.this'), admin_features_path(object) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+          <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+        <%  end %> <!-- END if current_perspecrtive  -->
+      <%  end %> <!-- END form_with -->
+      </div> <!-- END panel-body -->
+</section> <!-- END panel -->
+<style>
+#term_name {
+  width: 60%;
+}
+</style>

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -8,6 +8,8 @@ bo:
         detail:
             one: 'Term Detail'
             other: 'Term Details'
+        errors:
+            term_exists: 'Term is already on the dictionary, consider adding a new definition instead.'
         id_generator: 'Term ID Generator'
         numbers_to_generate: 'Number of terms to generate'
         range: 'Term Range'
@@ -25,6 +27,7 @@ bo:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
+                unicode_insert_request: 'Insert term in Tibetan Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -8,6 +8,8 @@ dz:
         detail:
             one: 'Term Detail'
             other: 'Term Details'
+        errors:
+            term_exists: 'Term is already on the dictionary, consider adding a new definition instead.'
         id_generator: 'Term ID Generator'
         numbers_to_generate: 'Number of terms to generate'
         range: 'Term Range'
@@ -25,6 +27,7 @@ dz:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
+                unicode_insert_request: 'Insert term in Tibetan Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -8,6 +8,8 @@ en:
         detail:
             one: 'Term Detail'
             other: 'Term Details'
+        errors:
+            term_exists: 'Term is already on the dictionary, consider adding a new definition instead.'
         id_generator: 'Term ID Generator'
         numbers_to_generate: 'Number of terms to generate'
         range: 'Term Range'
@@ -25,6 +27,7 @@ en:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
+                unicode_insert_request: 'Insert term in Tibetan Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -8,6 +8,8 @@ zh:
         detail:
             one: 'Term Detail'
             other: 'Term Details'
+        errors:
+            term_exists: 'Term is already on the dictionary, consider adding a new definition instead.'
         id_generator: 'Term ID Generator'
         numbers_to_generate: 'Number of terms to generate'
         range: 'Term Range'
@@ -25,6 +27,7 @@ zh:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
+                unicode_insert_request: 'Insert term in Tibetan Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,10 +16,11 @@ Rails.application.routes.draw do
     end
     resources :definition_relations
     resources :features do
-      resources :etymologies
+      post :create_tibetan_term, on: :collection
       resources :definitions do #, only: [:index, :show]
         get :locate_for_relation, on: :member
       end
+      resources :etymologies
       resources :recordings
       resources :subject_term_associations
     end

--- a/lib/terms_engine/engine.rb
+++ b/lib/terms_engine/engine.rb
@@ -2,6 +2,7 @@ module TermsEngine
   class Engine < ::Rails::Engine
     # isolate_namespace TermsEngine
     initializer :loader do |config|
+      require 'terms_engine/extension/admin_features_controller'
       require 'terms_engine/extension/feature_model'
       require 'terms_engine/extension/feature_controller'
       require 'terms_engine/extension/illustration_model'
@@ -12,6 +13,7 @@ module TermsEngine
       FeaturesController.send :include, TermsEngine::Extension::FeatureController
       Illustration.send :include, TermsEngine::Extension::IllustrationModel
       CitationsController.send :include, TermsEngine::Extension::CitationsController
+      Admin::FeaturesController.send :include, TermsEngine::Extension::AdminFeaturesController
     end
 
     config.generators do |g|

--- a/lib/terms_engine/extension/admin_features_controller.rb
+++ b/lib/terms_engine/extension/admin_features_controller.rb
@@ -1,0 +1,42 @@
+module TermsEngine
+  module Extension
+    module AdminFeaturesController
+      extend ActiveSupport::Concern
+
+      included do
+        new_action.wants.html {}
+
+        def create_tibetan_term
+          current_entry = params[:term_name].tibetan_cleanup
+          @current_term = Feature.search_expression(current_entry)
+          if @current_term.nil?
+            tib_alpha = Perspective.get_by_code('tib.alpha')
+            relation_type = FeatureRelationType.get_by_code('is.beginning.of')
+            parent = TermsService.recursive_trunk_for(current_entry)
+            if parent.ancestors_by_perspective(tib_alpha).count != 2
+              @object = Feature.new
+              object.errors.add :base, "There is a problem for term: #{current_entry} with calculated parent: #{parent.pid} in herarchy. Skipping term creation."
+              @name = current_entry
+            else
+              wylie = TermsService.get_wylie(current_entry)
+              phonetic = TermsService.get_phonetic(current_entry)
+              @current_term = TermsService.add_term(Feature::EXPRESSION_SUBJECT_ID, current_entry, wylie, phonetic)
+              @object = @current_term
+              FeatureRelation.create!(child_node: @current_term, parent_node: parent, perspective: tib_alpha, feature_relation_type: relation_type)
+              ts = TermsService.new(parent)
+              ts.reposition
+              @name = nil
+            end
+          else
+            @object = Feature.new
+            object.errors.add :base, t('feature.errors.term_exists')
+            @name = current_entry
+          end
+          respond_to do |format|
+            format.html { @name.nil? ? redirect_to(admin_feature_url(object.fid)) : render('admin/features/new') }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/terms_engine/version.rb
+++ b/lib/terms_engine/version.rb
@@ -1,3 +1,3 @@
 module TermsEngine
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6072

**Changes proposed in this pull request:**

 + Add new workflow for term creation, only for Tibetan terms

**Details of the implementation:**

Added a new workflow that just asks for the term in Tibetan Unicode,
then uses a THLib script to obtain the Wylie and phonetic representation
to create the new term.

This implementation takes advantage of  TermsServices to create new
terms. And the new workflow only takes effect if the perspective is `tib.alpha`