### PR TITLE
Added Definition Subject Association editorial interface - MANU-6106

### DIFF
--- a/app/assets/javascripts/terms_engine/definition_subject_associations_admin.js
+++ b/app/assets/javascripts/terms_engine/definition_subject_associations_admin.js
@@ -1,0 +1,130 @@
+$(document).ready(function() {
+  $("#branch_name").kmapsSimpleTypeahead({
+    solr_index: $('#definition_subject_association_js_data').data('termIndex'),
+    domain: $('#definition_subject_association_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+          //The return value includes the domain, i.e. subjects-653
+          $("#branch_id").val(sel.doc.id.replace($('#definition_subject_association_js_data').data('domain')+'-',''));
+          $("#subject_name").kmapsSimpleTypeahead('updateAdditionalFilters',["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:**/"+$('#branch_id').val()+"/*"]);
+      });
+  $("#subject_name").kmapsSimpleTypeahead({
+    solr_index: $('#definition_subject_association_js_data').data('termIndex'),
+    domain: $('#definition_subject_association_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    additional_filters: ["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:*/"+$('#branch_id').val()+"/*"],
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+        //The return value includes the domain, i.e. subjects-653
+        $("#subject_id").val(sel.doc.id.replace($('#definition_subject_association_js_data').data('domain')+'-',''));
+        }
+      );
+
+   var selectAncestorSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#definition_subject_association_js_data').data('termIndex'),
+    assetIndex: $('#definition_subject_association_js_data').data('assetIndex'),
+    featureId: $('#definition_subject_association_js_data').data('featureId'),
+    domain: $('#definition_subject_association_js_data').data('domain'),
+    perspective: $('#definition_subject_association_js_data').data('perspective'),
+    tree: $('#definition_subject_association_js_data').data('tree'), //places
+    featuresPath: $('#definition_subject_association_js_data').data('featuresPath'),
+  });
+  $("#branch_tree_container").kmapsRelationsTree({
+    featureId: $('#definition_subject_association_js_data').data('featureId'),
+    featuresPath: $('#definition_subject_association_js_data').data('featuresPath'),
+    termIndex: $('#definition_subject_association_js_data').data('termIndex'),
+    assetIndex: $('#definition_subject_association_js_data').data('assetIndex'),
+    perspective: $('#definition_subject_association_js_data').data('perspective'),
+    tree: $('#definition_subject_association_js_data').data('tree'), //places
+    domain: $('#definition_subject_association_js_data').data('domain'), //places
+    extraFields: ["header"],
+    descendants: false,
+    descendantsFullDetail: false,
+    displayPopup: false,
+    solrUtils: selectAncestorSolrUtils,
+    nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+  });
+  $("#branch_tree_container").on("fancytreeactivate", function(event, data){
+    $("#branch_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+    $("#branch_id").val(data.node.key.replace($('#definition_subject_association_js_data').data('domain')+'-',''));
+    $("#subject_name").kmapsSimpleTypeahead('updateAdditionalFilters',["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:**/"+$('#branch_id').val()+"/*"]);
+
+    if ($("#subject_tree_container")) {
+      $("#subject_tree_container").remove();
+      $("#subject_container").append('<div id="subject_tree_container"></div>');
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+
+    }
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#definition_subject_association_js_data').data('domain')+"-"+$('#branch_id').val(),
+      featuresPath: $('#definition_subject_association_js_data').data('featuresPath'),
+      termIndex: $('#definition_subject_association_js_data').data('termIndex'),
+      assetIndex: $('#definition_subject_association_js_data').data('assetIndex'),
+      perspective: $('#definition_subject_association_js_data').data('perspective'),
+      tree: $('#definition_subject_association_js_data').data('tree'), //places
+      domain: $('#definition_subject_association_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#definition_subject_association_js_data').data('domain')+'-',''));
+    });
+  });
+  if($("#branch_id").val() != '') {
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#definition_subject_association_js_data').data('domain')+"-"+$('#branch_id').val(),
+      featuresPath: $('#definition_subject_association_js_data').data('featuresPath'),
+      termIndex: $('#definition_subject_association_js_data').data('termIndex'),
+      assetIndex: $('#definition_subject_association_js_data').data('assetIndex'),
+      perspective: $('#definition_subject_association_js_data').data('perspective'),
+      tree: $('#definition_subject_association_js_data').data('tree'), //places
+      domain: $('#definition_subject_association_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#definition_subject_association_js_data').data('domain')+'-',''));
+    });
+  }
+
+  $("#subject_tree_container").hide();
+  $("#branch_tree_container").hide();
+  $("#js-expand-branch-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-branch-tree").text().includes('hide')){
+      $("#js-expand-branch-tree").text("Or click here to view branch hierarchy");
+    } else {
+      $("#js-expand-branch-tree").text("Or click here to hide branch hierarchy");
+    }
+    $("#branch_tree_container").toggle();
+  });
+  $("#js-expand-subject-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-subject-tree").text().includes('hide')){
+      $("#js-expand-subject-tree").text("Or click here to view subject hierarchy");
+    } else {
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+    }
+    $("#subject_tree_container").toggle();
+  });
+
+});

--- a/app/assets/stylesheets/terms_engine/application.css
+++ b/app/assets/stylesheets/terms_engine/application.css
@@ -12,6 +12,7 @@
  *= require mandala_terms/shanti-main-terms
  *= require terms_engine/recordings
  *= require terms_engine/subject_term_associations
+ *= require terms_engine/definition_subject_associations
  */
 
 body.page-terms .content-section {

--- a/app/assets/stylesheets/terms_engine/definition_subject_associations.css
+++ b/app/assets/stylesheets/terms_engine/definition_subject_associations.css
@@ -1,0 +1,9 @@
+.definition-subject-associations-form-fields input#branch_name, input#subject_name {
+    padding-left: 0;
+}
+.definition-subject-associations-form-fields .row, .twitter-typeahead {
+ margin: 0 0 0.2rem 1rem;
+}
+.definition-subject-associations-form-fields .row {
+  padding-top: 10px;
+}

--- a/app/controllers/admin/definition_subject_associations_controller.rb
+++ b/app/controllers/admin/definition_subject_associations_controller.rb
@@ -1,0 +1,17 @@
+class Admin::DefinitionSubjectAssociationsController < AclController
+  include KmapsEngine::ResourceObjectAuthentication
+  resource_controller
+
+  belongs_to :definition
+
+  new_action.before { object.branch_id = params[:branch_id] if params[:branch_id] }
+
+  destroy.wants.html { redirect_to admin_feature_definition_path(object.definition.feature,object.definition) }
+
+  protected
+
+  # Only allow a trusted parameter "white list" through.
+  def definition_subject_association_params
+    params.require(:definition_subject_association).permit(:definition_id, :subject_id, :branch_id)
+  end
+end

--- a/app/helpers/admin/definition_subject_associations_helper.rb
+++ b/app/helpers/admin/definition_subject_associations_helper.rb
@@ -1,0 +1,7 @@
+module Admin::DefinitionSubjectAssociationsHelper
+  def new_definition_subject_associations_links(definition)
+    DefinitionSubjectAssociation.select('branch_id').distinct.sort_by {|a| a.branch['header']}.collect do |a|
+      link_to "#{a.branch['header']} association", new_admin_definition_definition_subject_association_path(definition, branch_id: a.branch_id)
+    end.join(" | ").html_safe
+  end
+end

--- a/app/helpers/admin/subject_term_associations_helper.rb
+++ b/app/helpers/admin/subject_term_associations_helper.rb
@@ -1,9 +1,7 @@
 module Admin::SubjectTermAssociationsHelper
-  def new_subject_term_associations_links
-    SubjectTermAssociation.select('branch_id').distinct.sort_by {|a| a.branch['header']}.map do |a|
-      link_to "#{a.branch['header']} association", 
-        new_admin_feature_subject_term_association_path(object) +
-        "?branch_id=#{a.branch_id}"
+  def new_subject_term_associations_links(term)
+    SubjectTermAssociation.select('branch_id').distinct.sort_by {|a| a.branch['header']}.collect do |a|
+      link_to "#{a.branch['header']} association", new_admin_feature_subject_term_association_path(term, branch_id: a.branch_id)
     end.join(" | ").html_safe
   end
 end

--- a/app/views/admin/definition_relations/edit.html.erb
+++ b/app/views/admin/definition_relations/edit.html.erb
@@ -15,7 +15,7 @@
   <%=   render partial: 'form_fields', locals: {form: form} %>
   <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %> |
   <% if !defined?(parent_object) %>
-       <%= link_to 'Back', admin_path  %>
+       <%= link_to ts('back.this'), admin_path  %>
      <% else %>
        <%=  link_to ts('cancel.this'), admin_definition_definition_relations_path(parent_object), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>

--- a/app/views/admin/definition_relations/new.html.erb
+++ b/app/views/admin/definition_relations/new.html.erb
@@ -13,7 +13,7 @@
 <%=   render partial: 'form_fields', locals: {form: form} %>
   <%= globalized_submit_tag 'creat.e.this', class: 'btn btn-primary form-submit' %> |
   <% if !defined?(parent_object) %>
-       <%= link_to 'Back', admin_path  %>
+       <%= link_to ts('back.this'), admin_path  %>
      <% else %>
        <%=  link_to ts('cancel.this'), admin_definition_definition_relations_path(parent_object), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>

--- a/app/views/admin/definition_relations/show.html.erb
+++ b/app/views/admin/definition_relations/show.html.erb
@@ -18,9 +18,9 @@
     <%= @definition_relation.parent_node_id %>
     </p>
 
-     <%= link_to ts('Edit'), edit_admin_definition_definition_relation_path(object.child_node,@definition_relation), class: 'btn btn-primary form-submit' %> |
+     <%= link_to ts('edit.this'), edit_admin_definition_definition_relation_path(object.child_node,@definition_relation), class: 'btn btn-primary form-submit' %> |
      <% if !defined?(parent_object) %>
-       <%= link_to 'Back', admin_path  %>
+       <%= link_to ts('back.this'), admin_path  %>
      <% else %>
        <%=  link_to ts('cancel.this'), admin_definition_definition_relations_path(parent_object), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>

--- a/app/views/admin/definition_subject_associations/_form_fields.html.erb
+++ b/app/views/admin/definition_subject_associations/_form_fields.html.erb
@@ -1,7 +1,7 @@
-<div class="subject-term-associations-form-fields">
+<div class="definition-subject-associations-form-fields">
 <% if object.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(object.errors.count, "error") %> prohibited this subject term association from being saved:</h2>
+      <h2><%= pluralize(object.errors.count, "error") %> prohibited this definition subject association from being saved:</h2>
 
       <ul>
         <% object.errors.full_messages.each do |message| %>
@@ -11,9 +11,9 @@
     </div>
 <% end %>
 <fieldset>
-  <legend><%= ts(:for, what: t('information.general'), whom: SubjectTermAssociation.model_name.human.titleize) %></legend>
+  <legend><%= ts(:for, what: t('information.general'), whom: DefinitionSubjectAssociation.model_name.human.titleize) %></legend>
   <div class="row">
-    <%= form.label :branch_name, SubjectTermAssociation.human_attribute_name('branch').s %>
+    <%= form.label :branch_name, DefinitionSubjectAssociation.human_attribute_name('branch').s %>
     <br/>
     <br/>
     <%= form.hidden_field :branch_id, id: :branch_id %>
@@ -34,7 +34,7 @@
   </div>
 </fieldset>
 </div> <!-- END - subject-term-associations-form-fields -->
-<%= content_tag :div, '', id: 'subject_term_association_js_data', data: {
+<%= content_tag :div, '', id: 'definition_subject_association_js_data', data: {
  term_index: Feature.config.url,
  asset_index: Flare.config.asset_url,
  feature_id: '',
@@ -44,4 +44,4 @@
  features_path: new_admin_feature_path(parent_id: '%%ID%%'),
  mandala_path: 'https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs',
 } %>
-<%= javascript_include_tag 'terms_engine/subject_term_associations_admin' %>
+<%= javascript_include_tag 'terms_engine/definition_subject_associations_admin' %>

--- a/app/views/admin/definition_subject_associations/_list.html.erb
+++ b/app/views/admin/definition_subject_associations/_list.html.erb
@@ -4,15 +4,15 @@
    <table class="listGrid">
      <tr>
        <th class="listActionsCol"></th>
-       <th><%= SubjectTermAssociation.human_attribute_name('branch').s %></th>
+       <th><%= DefinitionSubjectAssociation.human_attribute_name('branch').s %></th>
        <th><%= SubjectsIntegration::Feature.human_name.titleize.s %></th>
      </tr>
 <%   list.each do |item| %>
      <tr>
        <td class="centerText">
-<%=      list_actions_for_item(item, :delete_path => admin_feature_subject_term_association_path(item.feature, item),
-         :edit_path => edit_admin_feature_subject_term_association_path(item.feature, item),
-         :view_path => admin_feature_subject_term_association_path(item.feature, item)) %>
+<%=      list_actions_for_item(item, :delete_path => admin_definition_definition_subject_association_path(item.definition, item),
+         :edit_path => edit_admin_definition_definition_subject_association_path(item.definition, item),
+         :view_path => admin_definition_definition_subject_association_path(item.definition, item)) %>
        </td>
        <td><%= item.branch['header'].s %></td>
        <td><%= item.subject['header'].s %></td>

--- a/app/views/admin/definition_subject_associations/edit.html.erb
+++ b/app/views/admin/definition_subject_associations/edit.html.erb
@@ -1,0 +1,17 @@
+<% add_breadcrumb_item feature_link(object.definition.feature)
+   add_breadcrumb_item link_to 'definition', admin_definition_path(object.definition)
+   add_breadcrumb_item object.id %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6>Editing <%= DefinitionSubjectAssociation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+    <%= form_with(model: [:admin, object.definition, object], local: true) do |form| %>
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <div class="actions">
+      <%=  link_to ts('cancel.this'), admin_feature_definition_path(object.definition.feature,object.definition) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
+      </div>
+    <% end %>
+  </div> <!-- END panel-body -->
+</section> <!-- END panel -->

--- a/app/views/admin/definition_subject_associations/index.html.erb
+++ b/app/views/admin/definition_subject_associations/index.html.erb
@@ -1,0 +1,10 @@
+<% add_breadcrumb_item link_to 'definition', admin_feature_definition_path(object.feature,object)
+%>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6><%= DefinitionSubjectAssociation.model_name.human.pluralize.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+<%=       render :partial => 'admin/definition_subject_associations/list', :locals => { :list => parent_object.definition_subject_associations } %>
+  </div> <!-- END panel-body -->
+</section> <!-- END panel -->

--- a/app/views/admin/definition_subject_associations/new.html.erb
+++ b/app/views/admin/definition_subject_associations/new.html.erb
@@ -1,0 +1,18 @@
+<% add_breadcrumb_item feature_link(object.definition.feature)
+   add_breadcrumb_item link_to 'definition', admin_feature_definition_path(object.definition.feature,object.definition)
+%>
+<div>
+  <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: DefinitionSubjectAssociation.model_name.human.titleize)), whom: "#{Definition.model_name.human.titleize} #{parent_object}" %></h1>
+</div>
+<%= form_with(model: [:admin, object.definition, object], local: true) do |form| %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6><%= DefinitionSubjectAssociation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <%=  link_to ts('cancel.this'), admin_feature_definition_path(object.definition.feature,object.definition) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->
+<% end %>

--- a/app/views/admin/definition_subject_associations/show.html.erb
+++ b/app/views/admin/definition_subject_associations/show.html.erb
@@ -1,0 +1,27 @@
+<% add_breadcrumb_item feature_link(object.definition.feature)
+   add_breadcrumb_item link_to 'definition', admin_feature_definition_path(object.definition.feature,object.definition)
+   add_breadcrumb_item object.id %>
+ <section class="panel panel-content">
+   <div class="panel-heading">
+     <h6><%= DefinitionSubjectAssociation.model_name.human.titleize.s %></h6>
+   </div>
+     <div class="panel-body">
+    <p id="notice"><%= notice %></p>
+
+    <p>
+    <strong><%= DefinitionSubjectAssociation.human_attribute_name('branch').s %>:</strong>
+    <%= object.branch['header'] %>
+    </p>
+    <p>
+    <strong><%= SubjectsIntegration::Feature.human_name.titleize.s %>:</strong>
+    <%= object.subject['header'] %>
+    </p>
+
+     <%= link_to ts('edit.this'), edit_admin_definition_definition_subject_association_path(object.definition, object), class: 'btn btn-primary form-submit' %> |
+     <% if !defined?(parent_object) %>
+       <%= link_to ts('back.this'), admin_path  %>
+     <% else %>
+       <%=  link_to ts('cancel.this'), admin_feature_definition_path(object.definition.feature, object.definition), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+     <% end %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -72,11 +72,26 @@
            </div> <!-- END panel-body -->
          </div> <!-- END collapseOne -->
        </section> <!-- END panel -->
+       <section class="panel panel-default">
+         <div class="panel-heading">
+           <h6><a href="#collapseTwo" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= DefinitionSubjectAssociation.model_name.human(count: :many).titleize.s %></a></h6>
+         </div>
+         <div id="collapseTwo" class="panel-collapse collapse">
+           <div class="panel-body">
+             <%=       highlighted_new_item_link [object, :definition_subject_association] %>
+             <br>
+             <h6>Create Specific Association:</h6>
+             <%= new_definition_subject_associations_links object %>
+             <br class="clear"/>
+             <%=       render :partial => 'admin/definition_subject_associations/list', :locals => { :list => object.definition_subject_associations } %>
+           </div> <!-- END panel-body -->
+         </div> <!-- END collapseTen -->
+       </section>
      </div> <!-- END accordion -->
 
-     <%= link_to ts('Edit'), edit_admin_feature_definition_path(parent_object,@definition), class: 'btn btn-primary form-submit' %> |
+     <%= link_to ts('edit.this'), edit_admin_feature_definition_path(parent_object,@definition), class: 'btn btn-primary form-submit' %> |
      <% if !defined?(parent_object) %>
-       <%= link_to 'Back', admin_definitions_path %>
+       <%= link_to ts('back.this'), admin_definitions_path %>
      <% else %>
        <%=  link_to ts('cancel.this'), admin_feature_path(parent_object.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -187,7 +187,7 @@
       <%=       highlighted_new_item_link [object, :subject_term_association] %>
       <br>
       <h6>Create Specific Association:</h6>
-      <%= new_subject_term_associations_links %>
+      <%= new_subject_term_associations_links object %>
       <br class="clear"/>
       <%=       render :partial => 'admin/subject_term_associations/list', :locals => { :list => object.subject_term_associations } %>
     </div> <!-- END panel-body -->

--- a/app/views/admin/recordings/_list.html.erb
+++ b/app/views/admin/recordings/_list.html.erb
@@ -4,7 +4,7 @@
    <table class="listGrid">
      <tr>
        <th class="listActionsCol"></th>
-       <th><%= ts('dialect', count: :many) %></th>
+       <th><%= Recording.human_attribute_name('dialect')%></th>
        <th><%= Recording.model_name.human.titleize.s %></th>
      </tr>
 <%   list.each do |item| %>

--- a/app/views/admin/recordings/show.html.erb
+++ b/app/views/admin/recordings/show.html.erb
@@ -9,7 +9,7 @@
     <p id="notice"><%= notice %></p>
 
     <p>
-    <strong><%= ts('dialect', count: 1)%>:</strong>
+    <strong><%= Recording.human_attribute_name('dialect')%>:</strong>
     <%= object.dialect['header'] %>
     </p>
 
@@ -21,9 +21,9 @@
       </audio>
     </button>
     </p>
-     <%= link_to ts('Edit'), edit_admin_feature_recording_path(object.feature, object), class: 'btn btn-primary form-submit' %> |
+     <%= link_to ts('edit.this'), edit_admin_feature_recording_path(object.feature, object), class: 'btn btn-primary form-submit' %> |
      <% if !defined?(parent_object) %>
-       <%= link_to 'Back', admin_path  %>
+       <%= link_to ts('back.this'), admin_path  %>
      <% else %>
        <%=  link_to ts('cancel.this'), admin_feature_path(object.feature), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>

--- a/app/views/admin/subject_term_associations/show.html.erb
+++ b/app/views/admin/subject_term_associations/show.html.erb
@@ -9,17 +9,17 @@
     <p id="notice"><%= notice %></p>
 
     <p>
-    <strong><%= ts('branch', count: 1)%>:</strong>
+    <strong><%= SubjectTermAssociation.human_attribute_name('branch').s %>:</strong>
     <%= object.branch['header'] %>
     </p>
     <p>
-    <strong><%= ts('subject', count: 1)%>:</strong>
+    <strong><%= SubjectsIntegration::Feature.human_name.titleize.s %>:</strong>
     <%= object.subject['header'] %>
     </p>
 
-     <%= link_to ts('Edit'), edit_admin_feature_subject_term_association_path(object.feature, object), class: 'btn btn-primary form-submit' %> |
+     <%= link_to ts('edit.this'), edit_admin_feature_subject_term_association_path(object.feature, object), class: 'btn btn-primary form-submit' %> |
      <% if !defined?(parent_object) %>
-       <%= link_to 'Back', admin_path  %>
+       <%= link_to ts('back.this'), admin_path  %>
      <% else %>
        <%=  link_to ts('cancel.this'), admin_feature_path(object.feature), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>

--- a/app/views/features/_other_dictionaries_definition.html.erb
+++ b/app/views/features/_other_dictionaries_definition.html.erb
@@ -1,3 +1,4 @@
+<% subject_associations = other_dictionaries_definition.definition_subject_associations %>
 <p>
 <%= other_dictionaries_definition.content.s.html_safe %>
 </p>
@@ -8,4 +9,10 @@
   <dl>
     <dt><%= Language.model_name.human %>:</dt> <dd><%= other_dictionaries_definition.language.name %></dd>
   </dl>
+  <% if !subject_associations.empty? %>
+    <h4><%= DefinitionSubjectAssociation.model_name.human(count: subject_associations.count).titleize.s %></h4>
+    <dl>
+      <%=  render partial: 'subjects', locals: { associations: subject_associations } %>
+    </dl>
+  <% end %>
 </div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,3 @@
 Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'stylesheets').to_s
 Rails.application.config.assets.paths << Rails.root.join('assets', 'stylesheets', 'terms_engine').to_s
-Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js','terms_engine/recordings_admin.js','terms_engine/subject_term_associations_admin.js'])
+Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js','terms_engine/recordings_admin.js','terms_engine/subject_term_associations_admin.js','terms_engine/definition_subject_associations_admin.js'])

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -4,8 +4,8 @@ bo:
         # Model names will be kept in lower case. Invoke .capitalize or .titleize if you need them in uppercase.
         models:
             definition_subject_association:
-                one: 'resource'
-                other: 'resources'
+                one: 'definition subject association'
+                other: 'definition subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -24,11 +24,21 @@ bo:
             geo_code_type:
                 one: 'term code type'
                 other: 'term code types'
+            recording:
+                one: 'recording'
+                other: 'recordings'
+            subject_term_association:
+                one: 'subject term association'
+                other: 'subject term associations'
             view:
                 one: 'term language'
                 other: 'term languages'
         # Attribute names will be titleized.
         attributes:
+            definition_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
@@ -39,3 +49,11 @@ bo:
                     other: 'Term Types'
                 old_pid: 'OLD TID'
                 pid: 'Term ID'
+            recording:
+                dialect:
+                    one: 'Dialect'
+                    other: 'Dialects'
+            subject_term_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -4,8 +4,8 @@ dz:
         # Model names will be kept in lower case. Invoke .capitalize or .titleize if you need them in uppercase.
         models:
             definition_subject_association:
-                one: 'resource'
-                other: 'resources'
+                one: 'definition subject association'
+                other: 'definition subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -24,11 +24,21 @@ dz:
             geo_code_type:
                 one: 'term code type'
                 other: 'term code types'
+            recording:
+                one: 'recording'
+                other: 'recordings'
+            subject_term_association:
+                one: 'subject term association'
+                other: 'subject term associations'
             view:
                 one: 'term language'
                 other: 'term languages'
         # Attribute names will be titleized.
         attributes:
+            definition_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
@@ -39,3 +49,11 @@ dz:
                     other: 'Term Types'
                 old_pid: 'OLD TID'
                 pid: 'Term ID'
+            recording:
+                dialect:
+                    one: 'Dialect'
+                    other: 'Dialects'
+            subject_term_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -7,8 +7,8 @@ en:
                 one: 'definition'
                 other: 'definitions'
             definition_subject_association:
-                one: 'resource'
-                other: 'resources'
+                one: 'definition subject association'
+                other: 'definition subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -33,11 +33,18 @@ en:
             recording:
                 one: 'recording'
                 other: 'recordings'
+            subject_term_association:
+                one: 'subject term association'
+                other: 'subject term associations'
             view:
                 one: 'term language'
                 other: 'term languages'
         # Attribute names will be titleized.
         attributes:
+            definition_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
@@ -48,3 +55,11 @@ en:
                     other: 'Term Types'
                 old_pid: 'OLD TID'
                 pid: 'Term ID'
+            recording:
+                dialect:
+                    one: 'Dialect'
+                    other: 'Dialects'
+            subject_term_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -3,12 +3,6 @@ en:
     app:
         short: 'Terms'
         this: 'Knowledge Maps of Terms'
-    branch:
-      one: 'Branch'
-      other: 'Branches'
-    dialect:
-      one: 'dialect'
-      other: 'dialects'
     entry: 'Terms Entry'
     feature:
         detail:

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -4,8 +4,8 @@ zh:
         # Model names will be kept in lower case. Invoke .capitalize or .titleize if you need them in uppercase.
         models:
             definition_subject_association:
-                one: 'resource'
-                other: 'resources'
+                one: 'definition subject association'
+                other: 'definition subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -24,11 +24,21 @@ zh:
             geo_code_type:
                 one: 'term code type'
                 other: 'term code types'
+            recording:
+                one: 'recording'
+                other: 'recordings'
+            subject_term_association:
+                one: 'subject term association'
+                other: 'subject term associations'
             view:
                 one: 'term language'
                 other: 'term languages'
         # Attribute names will be titleized.
         attributes:
+            definition_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
@@ -39,3 +49,11 @@ zh:
                     other: 'Term Types'
                 old_pid: 'OLD TID'
                 pid: 'Term ID'
+            recording:
+                dialect:
+                    one: 'Dialect'
+                    other: 'Dialects'
+            subject_term_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :definitions do
       resources :definition_relations
+      resources :definition_subject_associations
     end
     resources :definition_relations
     resources :features do

--- a/lib/terms_engine/version.rb
+++ b/lib/terms_engine/version.rb
@@ -1,3 +1,3 @@
 module TermsEngine
-  VERSION = '0.4.7'
+  VERSION = '0.4.8'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6106

**Changes proposed in this pull request:**

 + Add Editorial Interface for Definition to Subject Association

**Details of the implementation:**

Implemented the new editorial interface to handle Definition Subject
associations. Also able to display for the view mode.

TODO: fix name for DefinitionSubjectAssociation, currently it only shows
as "Resource".

