### PR TITLE
Add editorial interface for etymologies -MANU-6119

### DIFF
--- a/app/assets/javascripts/terms_engine/etymology_subject_associations_admin.js
+++ b/app/assets/javascripts/terms_engine/etymology_subject_associations_admin.js
@@ -1,0 +1,129 @@
+$(document).ready(function() {
+  $("#branch_name").kmapsSimpleTypeahead({
+    solr_index: $('#etymology_subject_association_js_data').data('termIndex'),
+    domain: $('#etymology_subject_association_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+          //The return value includes the domain, i.e. subjects-653
+          $("#branch_id").val(sel.doc.id.replace($('#etymology_subject_association_js_data').data('domain')+'-',''));
+          $("#subject_name").kmapsSimpleTypeahead('updateAdditionalFilters',["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:**/"+$('#branch_id').val()+"/*"]);
+      });
+  $("#subject_name").kmapsSimpleTypeahead({
+    solr_index: $('#etymology_subject_association_js_data').data('termIndex'),
+    domain: $('#etymology_subject_association_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    additional_filters: ["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:*/"+$('#branch_id').val()+"/*"],
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+        //The return value includes the domain, i.e. subjects-653
+        $("#subject_id").val(sel.doc.id.replace($('#etymology_subject_association_js_data').data('domain')+'-',''));
+        }
+      );
+
+   var selectAncestorSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#etymology_subject_association_js_data').data('termIndex'),
+    assetIndex: $('#etymology_subject_association_js_data').data('assetIndex'),
+    featureId: $('#etymology_subject_association_js_data').data('featureId'),
+    domain: $('#etymology_subject_association_js_data').data('domain'),
+    perspective: $('#etymology_subject_association_js_data').data('perspective'),
+    tree: $('#etymology_subject_association_js_data').data('tree'), //places
+    featuresPath: $('#etymology_subject_association_js_data').data('featuresPath'),
+  });
+  $("#branch_tree_container").kmapsRelationsTree({
+    featureId: $('#etymology_subject_association_js_data').data('featureId'),
+    featuresPath: $('#etymology_subject_association_js_data').data('featuresPath'),
+    termIndex: $('#etymology_subject_association_js_data').data('termIndex'),
+    assetIndex: $('#etymology_subject_association_js_data').data('assetIndex'),
+    perspective: $('#etymology_subject_association_js_data').data('perspective'),
+    tree: $('#etymology_subject_association_js_data').data('tree'), //places
+    domain: $('#etymology_subject_association_js_data').data('domain'), //places
+    extraFields: ["header"],
+    descendants: false,
+    descendantsFullDetail: false,
+    displayPopup: false,
+    solrUtils: selectAncestorSolrUtils,
+    nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+  });
+  $("#branch_tree_container").on("fancytreeactivate", function(event, data){
+    $("#branch_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+    $("#branch_id").val(data.node.key.replace($('#etymology_subject_association_js_data').data('domain')+'-',''));
+    $("#subject_name").kmapsSimpleTypeahead('updateAdditionalFilters',["ancestor_id_gen_path:"+$('#branch_id').val()+"/* OR ancestor_id_gen_path:**/"+$('#branch_id').val()+"/*"]);
+
+    if ($("#subject_tree_container")) {
+      $("#subject_tree_container").remove();
+      $("#subject_container").append('<div id="subject_tree_container"></div>');
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+
+    }
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#etymology_subject_association_js_data').data('domain')+"-"+$('#branch_id').val(),
+      featuresPath: $('#etymology_subject_association_js_data').data('featuresPath'),
+      termIndex: $('#etymology_subject_association_js_data').data('termIndex'),
+      assetIndex: $('#etymology_subject_association_js_data').data('assetIndex'),
+      perspective: $('#etymology_subject_association_js_data').data('perspective'),
+      tree: $('#etymology_subject_association_js_data').data('tree'), //places
+      domain: $('#etymology_subject_association_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#etymology_subject_association_js_data').data('domain')+'-',''));
+    });
+  });
+  if($("#branch_id").val() != '') {
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#etymology_subject_association_js_data').data('domain')+"-"+$('#branch_id').val(),
+      featuresPath: $('#etymology_subject_association_js_data').data('featuresPath'),
+      termIndex: $('#etymology_subject_association_js_data').data('termIndex'),
+      assetIndex: $('#etymology_subject_association_js_data').data('assetIndex'),
+      perspective: $('#etymology_subject_association_js_data').data('perspective'),
+      tree: $('#etymology_subject_association_js_data').data('tree'), //places
+      domain: $('#etymology_subject_association_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#etymology_subject_association_js_data').data('domain')+'-',''));
+    });
+  }
+
+  $("#subject_tree_container").hide();
+  $("#branch_tree_container").hide();
+  $("#js-expand-branch-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-branch-tree").text().includes('hide')){
+      $("#js-expand-branch-tree").text("Or click here to view branch hierarchy");
+    } else {
+      $("#js-expand-branch-tree").text("Or click here to hide branch hierarchy");
+    }
+    $("#branch_tree_container").toggle();
+  });
+  $("#js-expand-subject-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-subject-tree").text().includes('hide')){
+      $("#js-expand-subject-tree").text("Or click here to view subject hierarchy");
+    } else {
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+    }
+    $("#subject_tree_container").toggle();
+  });
+});

--- a/app/assets/javascripts/terms_engine/etymology_type_associations_admin.js
+++ b/app/assets/javascripts/terms_engine/etymology_type_associations_admin.js
@@ -1,0 +1,61 @@
+$(document).ready(function() {
+  var branch_id = $('#etymology_type_associations_js_data').data('branchId').replace($('#etymology_type_associations_js_data').data('domain')+'-','')
+  $("#subject_name").kmapsSimpleTypeahead({
+    solr_index: $('#etymology_type_associations_js_data').data('termIndex'),
+    domain: $('#etymology_type_associations_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    additional_filters: ["ancestor_id_gen_path:"+branch_id+"/* OR ancestor_id_gen_path:*/"+branch_id+"/*"],
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+        //The return value includes the domain, i.e. subjects-653
+        $("#subject_id").val(sel.doc.id.replace($('#etymology_type_associations_js_data').data('domain')+'-',''));
+        }
+      );
+   var selectAncestorSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#etymology_type_associations_js_data').data('termIndex'),
+    assetIndex: $('#etymology_type_associations_js_data').data('assetIndex'),
+    featureId: $('#etymology_type_associations_js_data').data('featureId'),
+    domain: $('#etymology_type_associations_js_data').data('domain'),
+    perspective: $('#etymology_type_associations_js_data').data('perspective'),
+    tree: $('#etymology_type_associations_js_data').data('tree'), //places
+    featuresPath: $('#etymology_type_associations_js_data').data('featuresPath'),
+  });
+
+    if($('#etymology_type_associations_js_data').data('branchId') != '') {
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#etymology_type_associations_js_data').data('branchId'),
+      featuresPath: $('#etymology_type_associations_js_data').data('featuresPath'),
+      termIndex: $('#etymology_type_associations_js_data').data('termIndex'),
+      assetIndex: $('#etymology_type_associations_js_data').data('assetIndex'),
+      perspective: $('#etymology_type_associations_js_data').data('perspective'),
+      tree: $('#etymology_type_associations_js_data').data('tree'), //places
+      domain: $('#etymology_type_associations_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#etymology_type_associations_js_data').data('domain')+'-',''));
+    });
+  }
+
+  $("#subject_tree_container").hide();
+
+  $("#js-expand-subject-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-subject-tree").text().includes('hide')){
+      $("#js-expand-subject-tree").text("Or click here to view subject hierarchy");
+    } else {
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+    }
+    $("#subject_tree_container").toggle();
+  });
+});

--- a/app/controllers/admin/etymologies_controller.rb
+++ b/app/controllers/admin/etymologies_controller.rb
@@ -1,0 +1,45 @@
+class Admin::EtymologiesController < AclController
+  include KmapsEngine::ResourceObjectAuthentication
+  resource_controller
+
+  belongs_to :definition, :feature
+
+  new_action.before do
+    object.build_etymology_type_association
+  end
+
+  edit.before do
+    if object.etymology_type_association.nil?
+      object.build_etymology_type_association
+    end
+  end
+
+  create.after do
+    object.create_etymology_type_association(etymology_type_association_params[:etymology_type_association_attributes])
+    if !object.valid?
+      object.destroy!
+      @object = Etymology.new(etymology_params)
+      object.build_etymology_type_association(etymology_type_association_params[:etymology_type_association_attributes])
+    end
+  end
+  
+  create.wants.html do
+    if object.id?
+      redirect_to(polymorphic_url([:admin, object.context, object]))
+    else
+      flash[:notice] = 'Etymology type associations failed to save.'
+      render :new
+    end
+  end
+
+  protected
+
+  # Only allow a trusted parameter "white list" through.
+  def etymology_params
+    params.require(:etymology).permit(:context_id, :context_type, :feature_id, :content)
+  end
+  
+  def etymology_type_association_params
+    params.require(:etymology).permit(etymology_type_association_attributes: [:id, :subject_id, :branch_id, :etymology_id])
+  end
+end

--- a/app/controllers/admin/etymology_subject_associations_controller.rb
+++ b/app/controllers/admin/etymology_subject_associations_controller.rb
@@ -1,0 +1,17 @@
+class Admin::EtymologySubjectAssociationsController < AclController
+  include KmapsEngine::ResourceObjectAuthentication
+  resource_controller
+
+  belongs_to :etymology
+
+  new_action.before { object.branch_id = params[:branch_id] if params[:branch_id] }
+
+  destroy.wants.html { redirect_to polymorphic_url([:admin,object.etymology]) }
+
+  protected
+
+  # Only allow a trusted parameter "white list" through.
+  def etymology_subject_association_params
+    params.require(:etymology_subject_association).permit(:etymology_id, :subject_id, :branch_id)
+  end
+end

--- a/app/controllers/admin/subject_term_associations_controller.rb
+++ b/app/controllers/admin/subject_term_associations_controller.rb
@@ -4,11 +4,7 @@ class Admin::SubjectTermAssociationsController < AclController
 
   belongs_to :feature
 
-  new_action.wants.html do
-    if params[:branch_id]
-      object.branch_id = params[:branch_id]
-    end
-  end
+  new_action.before { object.branch_id = params[:branch_id] if params[:branch_id] }
 
   protected
 

--- a/app/helpers/admin/etymology_subject_associations_helper.rb
+++ b/app/helpers/admin/etymology_subject_associations_helper.rb
@@ -1,0 +1,7 @@
+module Admin::EtymologySubjectAssociationsHelper
+  def new_etymology_subject_associations_links(etymology)
+    EtymologySubjectAssociation.select('branch_id').distinct.sort_by {|a| a.branch['header']}.collect do |a|
+      link_to "#{a.branch['header']} association", new_admin_etymology_etymology_subject_association_path(etymology, branch_id: a.branch_id)
+    end.join(" | ").html_safe
+  end
+end

--- a/app/models/etymology.rb
+++ b/app/models/etymology.rb
@@ -12,9 +12,16 @@
 
 class Etymology < ApplicationRecord
   include KmapsEngine::IsNotable
-  
+
   belongs_to :context, polymorphic: true
 
   has_many :etymology_subject_associations, dependent: :destroy
-  has_one :etymology_type_association
+  has_one :etymology_type_association, dependent: :destroy
+
+  accepts_nested_attributes_for :etymology_type_association 
+
+  def generic_etymology_subject_associations
+    etymology_subject_associations.where.not(branch_id: EtymologyTypeAssociation::BRANCH_ID)
+
+  end
 end

--- a/app/models/etymology_type_association.rb
+++ b/app/models/etymology_type_association.rb
@@ -11,5 +11,9 @@
 #
 
 class EtymologyTypeAssociation < EtymologySubjectAssociation
-  default_scope { where(branch_id: 182) }
+
+  BRANCH_ID=182
+
+  default_scope { where(branch_id: BRANCH_ID) }
+
 end

--- a/app/views/admin/definitions/edit.html.erb
+++ b/app/views/admin/definitions/edit.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'definitions', admin_feature_definitions_path(object.feature)
+   add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, admin_feature_definitions_path(object.feature)
    add_breadcrumb_item object.id %>
 <section class="panel panel-content">
   <div class="panel-heading">

--- a/app/views/admin/definitions/new.html.erb
+++ b/app/views/admin/definitions/new.html.erb
@@ -1,6 +1,6 @@
 <% 
 add_breadcrumb_item feature_link(object.feature)
-add_breadcrumb_item link_to 'definitions', admin_feature_definitions_path(object.feature)
+add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, admin_feature_definitions_path(object.feature)
 add_breadcrumb_item ts('new.this')
 %>
 <div><h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: Definition.model_name.human.titleize)), whom: "#{Feature.model_name.human.titleize} #{parent_object}" %></h1></div>

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -87,6 +87,19 @@
            </div> <!-- END panel-body -->
          </div> <!-- END collapseTen -->
        </section>
+       <section class="panel panel-default">
+         <div class="panel-heading">
+           <h6><a href="#collapseThree" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Etymology.model_name.human(count: :many).titleize.s %></a></h6>
+         </div>
+         <div id="collapseThree" class="panel-collapse collapse">
+           <div class="panel-body">
+             <%=       highlighted_new_item_link [object, :etymology] %>
+             <br>
+             <br class="clear"/>
+             <%=       render :partial => 'admin/etymologies/list', :locals => { :list => object.etymologies } %>
+           </div> <!-- END panel-body -->
+         </div> <!-- END collapseTen -->
+       </section>
      </div> <!-- END accordion -->
 
      <%= link_to ts('edit.this'), edit_admin_feature_definition_path(parent_object,@definition), class: 'btn btn-primary form-submit' %> |

--- a/app/views/admin/etymologies/_form_fields.html.erb
+++ b/app/views/admin/etymologies/_form_fields.html.erb
@@ -1,0 +1,60 @@
+<%= tinymce_assets %>
+<%= tinymce %>
+<% if object.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(object.errors.count, "error") %> prohibited this etymology from being saved:</h2>
+
+      <ul>
+        <% object.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+<% end %>
+<fieldset>
+  <legend><%= ts(:for, what: t('information.general'), whom: Etymology.model_name.human.titleize) %></legend>
+  <div class="row" id="subject_container">
+    <%= form.label :subject_name, Etymology.human_attribute_name('etymology_type_association').s %>
+    <br/>
+    <br/>
+    <%= form.hidden_field :context_id, value: object.context_id %>
+    <%= form.hidden_field :context_type, value: object.context_type %>
+    <%= form.fields_for :etymology_type_association do |type_form| %>
+      <%= type_form.hidden_field :subject_id, id: :subject_id %>
+      <% if !object.etymology_type_association.id.nil? %>
+        <%= type_form.hidden_field :id %>
+      <% end %>
+      <%= type_form.hidden_field :branch_id %>
+      <p>Search by name</p>
+      <% 
+          subject_name = ''
+      if !object.etymology_type_association.nil? && !object.etymology_type_association.subject.blank? 
+        subject_name = object.etymology_type_association.subject['header']
+      end
+    %>
+  <%= text_field_tag :subject_name, :post, { placeholder: 'Search by subject name', value: subject_name } %>
+  <a href="#" id="js-expand-subject-tree">Or click here to view subject hierarchy</a>
+  <div id="subject_tree_container"></div>
+<% end %>
+  </div>
+
+  <div class="row">
+    <%= form.label(:content).s %>
+  </div>
+  <div class="row">
+    <%= form.text_area :content, rows: 4, class: 'tinymce' %>
+  </div>
+
+</fieldset>
+<%= content_tag :div, '', id: 'etymology_type_associations_js_data', data: {
+ term_index: Feature.config.url,
+ asset_index: Flare.config.asset_url,
+ feature_id: '',
+ domain: 'subjects',
+ perspective: 'gen',
+ tree: 'subjects',
+ features_path: new_admin_feature_path(parent_id: '%%ID%%'),
+ mandala_path: 'https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs',
+ branch_id: "subjects-#{EtymologyTypeAssociation::BRANCH_ID}"
+} %>
+<%= javascript_include_tag 'terms_engine/etymology_type_associations_admin' %>

--- a/app/views/admin/etymologies/_list.html.erb
+++ b/app/views/admin/etymologies/_list.html.erb
@@ -1,0 +1,22 @@
+<% if list.empty? %>
+<%=  empty_collection_message %>
+<% else %>
+   <table class="listGrid">
+     <tr>
+       <th class="listActionsCol"></th>
+       <th><%= Etymology.model_name.human.titleize.s %></th>
+       <th><%= Etymology.human_attribute_name('object_type').s %></th>
+     </tr>
+<%   list.each do |item| %>
+     <tr>
+       <td class="centerText">
+         <%=      list_actions_for_item(item, delete_path: polymorphic_url([:admin, item.context,item]),
+         :edit_path => polymorphic_url([:admin, item.context,item], {action: :edit}),
+         :view_path => polymorphic_url([:admin, item.context,item])) %>
+       </td>
+       <td><%= item.content.s %></td>
+       <td><p><%= item.etymology_type_association.nil? ? "-" : item.etymology_type_association.subject['header'].s %></p></td>
+     </tr>
+<%   end %>
+   </table>
+<% end %>

--- a/app/views/admin/etymologies/edit.html.erb
+++ b/app/views/admin/etymologies/edit.html.erb
@@ -1,0 +1,26 @@
+<%
+if object.context.instance_of? Feature
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context])
+else
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context.feature])
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context.feature, object.context])
+end
+add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s , polymorphic_url([:admin, object.context, object])
+add_breadcrumb_item object.id
+%>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6>Editing <%= Etymology.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+<%= form_with(model: [:admin, object.context, object], local: true) do |form| %>
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <% if object.context.instance_of? Feature %>
+        <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.context]) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% else %>
+        <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.context.feature,  object.context]) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% end %>
+      <%=  globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
+<% end %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->

--- a/app/views/admin/etymologies/index.html.erb
+++ b/app/views/admin/etymologies/index.html.erb
@@ -1,0 +1,11 @@
+<%
+add_breadcrumb_item link_to parent_object.model_name.human.titleize.s, polymorphic_url([:admin, parent_object])
+%>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6><%= Etymology.model_name.human.pluralize.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+<%=       render :partial => 'admin/etymologies/list', :locals => { :list => parent_object.etymologies } %>
+  </div> <!-- END panel-body -->
+</section> <!-- END panel -->

--- a/app/views/admin/etymologies/new.html.erb
+++ b/app/views/admin/etymologies/new.html.erb
@@ -1,0 +1,29 @@
+<%
+if object.context.instance_of? Feature
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context])
+else
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context.feature])
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context.feature, object.context])
+end
+add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s , polymorphic_url([:admin, object.context, object])
+add_breadcrumb_item ts('new.this')
+%>
+<div>
+  <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: Etymology.model_name.human.titleize)), whom: "#{object.context.model_name.human.titleize} #{object.context}" %></h1>
+</div>
+<%= form_with(model: [:admin, object.context, object], local: true) do |form| %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6><%= Etymology.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <% if object.context.instance_of? Feature %>
+        <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.context]) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% else %>
+        <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.context.feature, object.context]) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% end %>
+      <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->
+<% end %>

--- a/app/views/admin/etymologies/show.html.erb
+++ b/app/views/admin/etymologies/show.html.erb
@@ -1,0 +1,58 @@
+<%
+if object.context.instance_of? Feature
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context])
+else
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context.feature])
+  add_breadcrumb_item link_to object.context.model_name.human.titleize.s, polymorphic_url([:admin, object.context.feature, object.context])
+end
+add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s , polymorphic_url([:admin, object.context, object])
+add_breadcrumb_item object.id
+%>
+ <section class="panel panel-content">
+   <div class="panel-heading">
+     <h6><%= Etymology.model_name.human.titleize.s %></h6>
+   </div>
+   <div class="panel-body">
+     <div>
+       <h1><%= Etymology.model_name.human.titleize.s %>:</h1>
+       <p>
+       <%= object.content.s %>
+       </p>
+       <% if !object.etymology_type_association.blank? %>
+         <h1><%= EtymologyTypeAssociation.model_name.human.titleize.s %>:</h1>
+         <p>
+         <%= object.etymology_type_association.subject['header'].s %>
+         </p>
+       <% end %>
+     </div>
+     <br class="clear"/>
+     <div id="accordion" class="panel-group">
+       <section class="panel panel-default">
+         <div class="panel-heading">
+           <h6><a href="#collapseOne" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= EtymologySubjectAssociation.model_name.human(count: :many).titleize.s %></a></h6>
+         </div>
+         <div id="collapseOne" class="panel-collapse in">
+           <div class="panel-body">
+             <%=       highlighted_new_item_link [object, :etymology_subject_association] %>
+             <br>
+             <h6>Create Specific Association:</h6>
+             <%= new_etymology_subject_associations_links object %>
+             <br class="clear"/>
+             <%=       render :partial => 'admin/etymology_subject_associations/list', locals: { list: object.generic_etymology_subject_associations } %>
+           </div> <!-- END panel-body -->
+         </div> <!-- END collapseTen -->
+       </section>
+     </div> <!-- END accordion -->
+
+     <%= link_to ts('edit.this'), polymorphic_url([:admin, object.context,object], {action: :edit}), class: 'btn btn-primary form-submit' %> |
+     <% if !defined?(object.context) %>
+       <%= link_to ts('back.this'), admin_etymologies_path %>
+     <% else %>
+       <% if object.context.instance_of? Feature %>
+         <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.context]), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+       <% else %>
+         <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.context.feature, object.context]), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+       <% end %>
+     <% end %>
+   </div> <!-- END panel-body -->
+ </section> <!-- END panel -->

--- a/app/views/admin/etymology_subject_associations/_form_fields.html.erb
+++ b/app/views/admin/etymology_subject_associations/_form_fields.html.erb
@@ -1,0 +1,47 @@
+<div class="etymology-subject-associations-form-fields">
+<% if object.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(object.errors.count, "error") %> prohibited this etymology subject association from being saved:</h2>
+
+      <ul>
+        <% object.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+<% end %>
+<fieldset>
+  <legend><%= ts(:for, what: t('information.general'), whom: EtymologySubjectAssociation.model_name.human.titleize) %></legend>
+  <div class="row">
+    <%= form.label :branch_name, EtymologySubjectAssociation.human_attribute_name('branch').s %>
+    <br/>
+    <br/>
+    <%= form.hidden_field :branch_id, id: :branch_id %>
+    <p>Search by name</p>
+    <%= text_field_tag :branch_name, :post, { placeholder: 'Search by branch name', value: object.branch.blank? ? '' : object.branch['header'] } %>
+    <a href="#" id="js-expand-branch-tree">Or click here to view branch hierarchy</a>
+     <div id="branch_tree_container"></div>
+  </div>
+  <div class="row" id="subject_container">
+    <%= form.label :subject_name, SubjectsIntegration::Feature.human_name(count: 1).titleize %>
+    <br/>
+    <br/>
+    <%= form.hidden_field :subject_id, id: :subject_id %>
+    <p>Search by name</p>
+    <%= text_field_tag :subject_name, :post, { placeholder: 'Search by subject name', value: object.subject.blank? ? '' : object.subject['header'] } %>
+    <a href="#" id="js-expand-subject-tree">Or click here to view subject hierarchy</a>
+     <div id="subject_tree_container"></div>
+  </div>
+</fieldset>
+</div> <!-- END - subject-term-associations-form-fields -->
+<%= content_tag :div, '', id: 'etymology_subject_association_js_data', data: {
+ term_index: Feature.config.url,
+ asset_index: Flare.config.asset_url,
+ feature_id: '',
+ domain: 'subjects',
+ perspective: 'gen',
+ tree: 'subjects',
+ features_path: new_admin_feature_path(parent_id: '%%ID%%'),
+ mandala_path: 'https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs',
+} %>
+<%= javascript_include_tag 'terms_engine/etymology_subject_associations_admin' %>

--- a/app/views/admin/etymology_subject_associations/_list.html.erb
+++ b/app/views/admin/etymology_subject_associations/_list.html.erb
@@ -1,0 +1,22 @@
+<% if list.empty? %>
+<%=  empty_collection_message %>
+<% else %>
+   <table class="listGrid">
+     <tr>
+       <th class="listActionsCol"></th>
+       <th><%= EtymologySubjectAssociation.human_attribute_name('branch').s %></th>
+       <th><%= SubjectsIntegration::Feature.human_name.titleize.s %></th>
+     </tr>
+<%   list.each do |item| %>
+     <tr>
+       <td class="centerText">
+<%=      list_actions_for_item(item, :delete_path => admin_etymology_etymology_subject_association_path(item.etymology, item),
+         :edit_path => edit_admin_etymology_etymology_subject_association_path(item.etymology, item),
+         :view_path => admin_etymology_etymology_subject_association_path(item.etymology, item)) %>
+       </td>
+       <td><%= item.branch['header'].s %></td>
+       <td><%= item.subject['header'].s %></td>
+     </tr>
+<%   end %>
+   </table>
+<% end %>

--- a/app/views/admin/etymology_subject_associations/edit.html.erb
+++ b/app/views/admin/etymology_subject_associations/edit.html.erb
@@ -1,0 +1,22 @@
+<%
+if object.etymology.context.instance_of? Feature
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context])
+else
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context.feature])
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context.feature, object.etymology.context])
+end
+add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s , polymorphic_url([:admin, object.etymology.context, object.etymology])
+add_breadcrumb_item object.id
+%>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6><%= EtymologySubjectAssociation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+<%= form_with(model: [:admin, object.etymology, object], local: true) do |form| %>
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.etymology.context,object.etymology]) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <%=  globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
+<% end %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->

--- a/app/views/admin/etymology_subject_associations/new.html.erb
+++ b/app/views/admin/etymology_subject_associations/new.html.erb
@@ -1,0 +1,29 @@
+<%
+if object.etymology.context.instance_of? Feature
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context])
+else
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context.feature])
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context.feature, object.etymology.context])
+end
+add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s , polymorphic_url([:admin, object.etymology.context, object.etymology])
+add_breadcrumb_item ts('new.this')
+%>
+<div>
+  <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: EtymologySubjectAssociation.model_name.human.titleize)), whom: "#{Etymology.model_name.human.titleize} #{object.etymology}" %></h1>
+</div>
+<%= form_with(model: [:admin, object.etymology, object], local: true) do |form| %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6><%= EtymologySubjectAssociation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <% if object.etymology.context.instance_of? Feature %>
+        <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.etymology.context]) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% else %>
+        <%=  link_to ts('cancel.this'), polymorphic_url([:admin, object.etymology.context.feature, object.etymology.context]) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% end %>
+      <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->
+<% end %>

--- a/app/views/admin/etymology_subject_associations/show.html.erb
+++ b/app/views/admin/etymology_subject_associations/show.html.erb
@@ -1,0 +1,34 @@
+<%
+if object.etymology.context.instance_of? Feature
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context])
+else
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context.feature])
+  add_breadcrumb_item link_to object.etymology.context.model_name.human.titleize.s, polymorphic_url([:admin, object.etymology.context.feature, object.etymology.context])
+end
+add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s , polymorphic_url([:admin, object.etymology.context, object.etymology])
+add_breadcrumb_item object.id
+%>
+ <section class="panel panel-content">
+   <div class="panel-heading">
+     <h6><%= EtymologySubjectAssociation.model_name.human.titleize.s %></h6>
+   </div>
+     <div class="panel-body">
+    <p id="notice"><%= notice %></p>
+
+    <p>
+    <strong><%= EtymologySubjectAssociation.human_attribute_name('branch').s %>:</strong>
+    <%= object.branch['header'] %>
+    </p>
+    <p>
+    <strong><%= SubjectsIntegration::Feature.human_name.titleize.s %>:</strong>
+    <%= object.subject['header'] %>
+    </p>
+
+     <%= link_to ts('edit.this'), edit_admin_etymology_etymology_subject_association_path(object.etymology, object), class: 'btn btn-primary form-submit' %> |
+     <% if !defined?(object.etymology) %>
+       <%= link_to ts('back.this'), admin_path  %>
+     <% else %>
+       <%=  link_to ts('cancel.this'), polymorphic_url([:admin,object.etymology.context,object.etymology]), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+     <% end %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -193,5 +193,18 @@
     </div> <!-- END panel-body -->
   </div> <!-- END collapseTen -->
 </section>
+<section class="panel panel-default">
+  <div class="panel-heading">
+    <h6><a href="#collapseThirteen" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Etymology.model_name.human(count: :many).titleize.s %></a></h6>
+  </div>
+  <div id="collapseThirteen" class="panel-collapse collapse">
+    <div class="panel-body">
+      <%=       highlighted_new_item_link [object, :etymology] %>
+      <br>
+      <br class="clear"/>
+      <%=       render :partial => 'admin/etymologies/list', :locals => { :list => object.etymologies } %>
+    </div> <!-- END panel-body -->
+  </div> <!-- END collapseTen -->
+</section>
   </div> <!-- END accordion -->
 </div> <!-- END featureShow -->

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,8 @@
 Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'stylesheets').to_s
 Rails.application.config.assets.paths << Rails.root.join('assets', 'stylesheets', 'terms_engine').to_s
-Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js','terms_engine/recordings_admin.js','terms_engine/subject_term_associations_admin.js','terms_engine/definition_subject_associations_admin.js'])
+Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js','terms_engine/recordings_admin.js',
+                                                   'terms_engine/subject_term_associations_admin.js',
+                                                   'terms_engine/definition_subject_associations_admin.js',
+                                                   'terms_engine/etymology_type_associations_admin.js',
+                                                   'terms_engine/etymology_subject_associations_admin.js',
+                                                   ])

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -3,9 +3,21 @@ bo:
     activerecord:
         # Model names will be kept in lower case. Invoke .capitalize or .titleize if you need them in uppercase.
         models:
+            definition:
+                one: 'definition'
+                other: 'definitions'
             definition_subject_association:
                 one: 'definition subject association'
                 other: 'definition subject associations'
+            etymology:
+                one: 'etymology'
+                other: 'etymologies'
+            etymology_type_association:
+                one: 'etymology type association'
+                other: 'etymology type associations'
+            etymology_subject_association:
+                one: 'etymology subject association'
+                other: 'etymology subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -39,10 +51,21 @@ bo:
                 branch:
                     one: 'Branch'
                     other: 'Branches'
+            etymology:
+                content:
+                    one: 'Content'
+                    other: 'Contents'
+                etymology_type_association:
+                    one: 'Etymology Type'
+                    other: 'Etymology Types'
+            etymology_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
-                    other: 'Contained Term'
+                    other: 'Contained Terms'
                 is_public: 'Public?'
                 object_type:
                     one: 'Term Type'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -3,9 +3,21 @@ dz:
     activerecord:
         # Model names will be kept in lower case. Invoke .capitalize or .titleize if you need them in uppercase.
         models:
+            definition:
+                one: 'definition'
+                other: 'definitions'
             definition_subject_association:
                 one: 'definition subject association'
                 other: 'definition subject associations'
+            etymology:
+                one: 'etymology'
+                other: 'etymologies'
+            etymology_type_association:
+                one: 'etymology type association'
+                other: 'etymology type associations'
+            etymology_subject_association:
+                one: 'etymology subject association'
+                other: 'etymology subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -39,10 +51,21 @@ dz:
                 branch:
                     one: 'Branch'
                     other: 'Branches'
+            etymology:
+                content:
+                    one: 'Content'
+                    other: 'Contents'
+                etymology_type_association:
+                    one: 'Etymology Type'
+                    other: 'Etymology Types'
+            etymology_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
-                    other: 'Contained Term'
+                    other: 'Contained Terms'
                 is_public: 'Public?'
                 object_type:
                     one: 'Term Type'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -9,6 +9,15 @@ en:
             definition_subject_association:
                 one: 'definition subject association'
                 other: 'definition subject associations'
+            etymology:
+                one: 'etymology'
+                other: 'etymologies'
+            etymology_type_association:
+                one: 'etymology type association'
+                other: 'etymology type associations'
+            etymology_subject_association:
+                one: 'etymology subject association'
+                other: 'etymology subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -45,10 +54,21 @@ en:
                 branch:
                     one: 'Branch'
                     other: 'Branches'
+            etymology:
+                content:
+                    one: 'Content'
+                    other: 'Contents'
+                etymology_type_association:
+                    one: 'Etymology Type'
+                    other: 'Etymology Types'
+            etymology_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
-                    other: 'Contained Term'
+                    other: 'Contained Terms'
                 is_public: 'Public?'
                 object_type:
                     one: 'Term Type'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -3,9 +3,21 @@ zh:
     activerecord:
         # Model names will be kept in lower case. Invoke .capitalize or .titleize if you need them in uppercase.
         models:
+            definition:
+                one: 'definition'
+                other: 'definitions'
             definition_subject_association:
                 one: 'definition subject association'
                 other: 'definition subject associations'
+            etymology:
+                one: 'etymology'
+                other: 'etymologies'
+            etymology_type_association:
+                one: 'etymology type association'
+                other: 'etymology type associations'
+            etymology_subject_association:
+                one: 'etymology subject association'
+                other: 'etymology subject associations'
             feature:
                 one: 'term'
                 other: 'terms'
@@ -39,10 +51,21 @@ zh:
                 branch:
                     one: 'Branch'
                     other: 'Branches'
+            etymology:
+                content:
+                    one: 'Content'
+                    other: 'Contents'
+                etymology_type_association:
+                    one: 'Etymology Type'
+                    other: 'Etymology Types'
+            etymology_subject_association:
+                branch:
+                    one: 'Branch'
+                    other: 'Branches'
             feature:
                 descendant:
                     one: 'Contained Term'
-                    other: 'Contained Term'
+                    other: 'Contained Terms'
                 is_public: 'Public?'
                 object_type:
                     one: 'Term Type'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,15 +6,21 @@ Rails.application.routes.draw do
   resources :recordings, only: [:show]
   namespace :admin do
     resources :definitions do
+      resources :etymologies
       resources :definition_relations
       resources :definition_subject_associations
     end
+    resources :etymologies do
+      resources :etymology_type_associations
+      resources :etymology_subject_associations
+    end
     resources :definition_relations
     resources :features do
-      resources :recordings
+      resources :etymologies
       resources :definitions do #, only: [:index, :show]
         get :locate_for_relation, on: :member
       end
+      resources :recordings
       resources :subject_term_associations
     end
   end


### PR DESCRIPTION
**Jira Issue:** MANU-6119

**Changes proposed in this pull request:**

 + Adds editorial interface for etymologies, support for Features and Definitions

**Details of the implementation:**
Etymologies could be related to a Feature or a Definition.
TODO:
Add locales for other languages (Check en)
Review if we can change the implementation of `def create` on
etymologies_controller.rb