### PR TITLE
Update play icon for Recordings - MANU-5930

### DIFF
--- a/app/assets/stylesheets/terms_engine/recordings.css
+++ b/app/assets/stylesheets/terms_engine/recordings.css
@@ -3,11 +3,41 @@ audio{
 }
 
 .recording-play-button {
-  border: 2px solid #a57546;
+  width: 3rem;
+  height: 3rem;
+  background-color: #a2733f;
+  border: .3rem double #fff;
   border-radius: 50%;
-  width: 25px;
-  height: 25px;
-  color: #a57546;
+  color: white;
+  margin-right: 1.5rem;
+  cursor: pointer;
+  text-align: center;
+  margin-top: -.15rem;
+  opacity:.85;
+  -webkit-transform: scale(1.175);
+  transform: scale(1.175);
+  -webkit-transition: all .3s ease-in-out;
+  transition: all .15s ease-in-out;
+}
+.recording-play-button:hover {
+  opacity:1;
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1)
+}
+.recording-play-button:focus,
+.recording-play-button:active {
+  -webkit-transform: scale(1.225);
+  transform: scale(1.225);
+}
+.recording-play-button .icon{
+    position: relative;
+    top: .15rem;
+    right: .05rem;
+}
+.recording-play-button .icon:before {
+  position: relative;
+  top: 0.1rem;
+  left: .025rem
 }
 
 .recording-controls, .recording-list {
@@ -32,36 +62,7 @@ audio{
   display: inline;
   width: 40px;
 }
-.recording-play-button{
-    background: white;
-    -webkit-transform: scale(1.175);
-    transform: scale(1.175);
-    filter: alpha(opacity=80);
-    opacity: .8;
-       -webkit-transition: all .3s ease-in-out;
-        transition: all .3s ease-in-out;
-}
 
-.recording-play-button:hover{
-    filter: alpha(opacity=100);
-    opacity: 1;
-    -webkit-transform: scale(1.2);
-            transform: scale(1.2);
-}
-
-.recording-play-button .fa-play:before{
-    position: relative;
-    top: 0.1rem;
-    left: .025rem;
-}
-
-.recording-play-button:focus,
-.recording-play-button:active{
-    -webkit-transform: scale(1);
-    transform: scale(1);
-    filter: alpha(opacity=100);
-    opacity: 1;
-}
 
 .bootstrap-select.btn-group .dropdown-menu li > a::before {
     content: '';

--- a/app/views/recordings/_list.html.erb
+++ b/app/views/recordings/_list.html.erb
@@ -3,7 +3,9 @@
     <div class="recording-wrapper">
 
       <div class="recording-controls">
-      <button id="recording-play-button" class="recording-play-button fa fa-play"></button>
+        <div id="recording-play-button" class="recording-play-button">
+          <span class="icon shanticon-audio"></span>
+        </div>
       </div>
       <div class="recording-list">
       <label class="sr-only" for="selection">Listen to Audio for Term Pronunciations:</label>

--- a/lib/terms_engine/version.rb
+++ b/lib/terms_engine/version.rb
@@ -1,3 +1,3 @@
 module TermsEngine
-  VERSION = '0.4.8'
+  VERSION = '0.4.9'
 end


### PR DESCRIPTION

**Jira Issue:** MANU-5930

**Changes proposed in this pull request:**

 + Change the play button for recordings on the user view mode

**Details of the implementation:**

Previously a play button appeared for the recordings of each term, now
we change the icon to be a speaker to have a more universal icon. The
icon before was a button now is just a regular span that has animations
via CSS.

