### PR TITLE
Add Definition support for multiple authors - MANU-6132

### DIFF
--- a/app/controllers/admin/definitions_controller.rb
+++ b/app/controllers/admin/definitions_controller.rb
@@ -25,6 +25,18 @@ class Admin::DefinitionsController < AclController
     @authors = AuthenticatedSystem::Person.order('fullname')
   end
 
+  def update
+    object.update(definition_params)
+    author_ids = definition_params[:author_ids].blank? ? [] : definition_params[:author_ids]
+    object.author_ids = author_ids
+    redirect_to admin_feature_definition_path(object.feature,object)
+  end
+
+  # renders add_author.js.erb
+  def add_author
+    @authors = AuthenticatedSystem::Person.order('fullname')
+  end
+
   def locate_for_relation
     @locating_relation=true # flag used in template
     # Remove the Feature that is currently looking for a relation
@@ -57,6 +69,6 @@ class Admin::DefinitionsController < AclController
   end
   # Only allow a trusted parameter "white list" through.
   def definition_params
-    params.require(:definition).permit(:feature_id, :is_public, :is_primary, :ancestor_ids, :position, :content, :author_id, :language_id, :numerology, :tense)
+    params.require(:definition).permit(:feature_id, :is_public, :is_primary, :ancestor_ids, :position, :content, :language_id, :numerology, :tense, author_ids: [])
   end
 end

--- a/app/models/definition.rb
+++ b/app/models/definition.rb
@@ -29,7 +29,10 @@ class Definition < ApplicationRecord
   
   belongs_to :feature
   belongs_to :language
-  belongs_to :author, :class_name => 'AuthenticatedSystem::Person', optional: true
+  #belongs_to :author, :class_name => 'AuthenticatedSystem::Person', optional: true
+
+  has_and_belongs_to_many :authors, class_name: 'AuthenticatedSystem::Person', join_table: 'authors_definitions', association_foreign_key: 'author_id'
+
   has_many :definition_subject_associations, dependent: :destroy
   has_many :association_notes, as: :notable, dependent: :destroy
   has_many :legacy_citations, -> { where(info_source_type: InfoSource.model_name.name) }, as: :citable, class_name: 'Citation'

--- a/app/views/admin/definitions/_authors_selector.html.erb
+++ b/app/views/admin/definitions/_authors_selector.html.erb
@@ -1,0 +1,6 @@
+<div class="dropdown">
+<p>
+<%= select_tag 'definition[author_ids][]', options_for_select(@authors.collect{|a| [ a.fullname , a.id]}, selected.nil? ? nil : selected), class: 'form-control form-select ss-select selectpicker' %>
+<%= link_to ts(:remove), '#', onclick: "$(this).parents('.dropdown:first').remove()" %>
+</p>
+</div>

--- a/app/views/admin/definitions/_form_fields.html.erb
+++ b/app/views/admin/definitions/_form_fields.html.erb
@@ -43,6 +43,15 @@
   <div class="row">
   <%= form.collection_select :language_id, @languages, :id, :to_s, {include_blank: false}, class: 'form-control form-select ss-select selectpicker' %>
   </div>
+
+<p><%= link_to ts('add.record', what: t('new.record', what: t(:author, count: 1))), add_author_admin_definitions_path(object), remote: true %></p>
+  <div id="authors_div">
+    <%  for author in object.authors %>
+      <%=   render partial: 'authors_selector', locals: {selected: author.id} %>
+    <%  end %>
+  </div>
+  <div id="update_div"/>
+
   <p><b><%= form.label :author_id, ts(:author, count: 1).titleize %></b></p><br/>
   <div class="row">
   <%= form.collection_select :author_id, @authors, :id, :fullname, {include_blank: false} , class: 'form-control form-select ss-select selectpicker' %>

--- a/app/views/admin/definitions/add_author.js.erb
+++ b/app/views/admin/definitions/add_author.js.erb
@@ -1,0 +1,1 @@
+$("#update_div").before("<%= escape_javascript(render(:partial => 'authors_selector', :locals => {:selected => nil})) %>");

--- a/app/views/features/_definition.html.erb
+++ b/app/views/features/_definition.html.erb
@@ -25,7 +25,7 @@ subject_associations = definition.definition_subject_associations %>
         <% if !definition.numerology.nil? %>
           <dt><%= Definition.human_attribute_name(:numerology).s %>:</dt> <dd><%= definition.numerology %></dd>
         <% end %>
-        <% if !definition.author.nil? %>
+        <% if !definition.authors.blank? %>
           <dt><%= Definition.human_attribute_name(:author).s %>:</dt> <dd><%= definition.author.fullname %></dd>
         <% end %>
       </dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,11 @@ Rails.application.routes.draw do
   end
   resources :recordings, only: [:show]
   namespace :admin do
+    concern :add_author do
+      get :add_author, on: :collection
+    end
+
+    resources :definitions, concerns: :add_author
     resources :definitions do
       resources :definition_relations
       resources :definition_subject_associations

--- a/db/migrate/20190829152349_create_join_table_authors_definitions.rb
+++ b/db/migrate/20190829152349_create_join_table_authors_definitions.rb
@@ -1,0 +1,6 @@
+class CreateJoinTableAuthorsDefinitions < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :authors, :definitions do |t|
+    end
+  end
+end


### PR DESCRIPTION

**Jira Issue:** MANU-6132

**Changes proposed in this pull request:**

 + Adds multiple author support to Definitions

**Details of the implementation:**

I created an intermediate table `authors_definitions` to keep the
relation between definitions and authors. The migration has to be run on
Terms, and update the Schema. Same for tests.

Also had to overwrite the definitions_controller `update` because
ActiveResource wouldn't be able to handle the change in `author_ids`
properly.

Based my solution on kmaps_engine descriptions authors associations.

**TODO** If we keep the multiple authors we need to make sure to migrate the data.