### PR TITLE
Add multiple projects support - MANU-6183

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ gem 'complex_scripts',            '3.0.9',        github: 'thl/complex_scripts',
 gem 'flare',                      '1.2.3',        github: 'shanti-uva/flare',                tag: 'v1.2.3' #path: '../flare'
 gem 'ffi-icu',                    '0.2.0',        github: 'shanti-uva/ffi-icu',              tag: 'v0.2.0' #path: '../engines/ffi-icu'
 gem 'interface_utils',            '2.3.7',        github: 'thl/interface_utils',             tag: 'v2.3.7' #path: '../../thl/engines/interface_utils'
-gem 'kmaps_engine',               '5.7.7',        github: 'shanti-uva/kmaps_engine',         tag: 'v5.7.7' #path: '../kmaps_engine'
+gem 'kmaps_engine',               '5.7.8',        github: 'shanti-uva/kmaps_engine',         tag: 'v5.7.8' #path: '../kmaps_engine'
+gem 'shanti_integration',         '3.4.6',        github: 'shanti-uva/shanti_integration',   tag: 'v3.4.6' #path: '../engines/shanti_integration'
 gem 'resource_controller',        '0.9.2',        github: 'shanti-uva/resource_controller',  tag: 'v0.9.2' #path: '../resource_controller'
 gem 'dictionary_to_terms',        '0.3.4',        github: 'shanti-uva/dictionary_to_terms',  tag: 'v0.3.4' #path: '../dictionary_to_terms'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,10 +32,10 @@ GIT
 
 GIT
   remote: git://github.com/shanti-uva/kmaps_engine.git
-  revision: 577a35d07c36af9a3817e46f6a01fa3000a56ea2
-  tag: v5.7.7
+  revision: 2bbdf221b99cf648d32e41cca2cea832cc67f3e9
+  tag: v5.7.8
   specs:
-    kmaps_engine (5.7.7)
+    kmaps_engine (5.7.8)
       annotate
       bootsnap (>= 1.1.0)
       coffee-rails (~> 4.2)
@@ -56,6 +56,14 @@ GIT
   tag: v0.9.2
   specs:
     resource_controller (0.9.2)
+
+GIT
+  remote: git://github.com/shanti-uva/shanti_integration.git
+  revision: 3c1ec2ef91ac456cc139da508fd52f98416da727
+  tag: v3.4.6
+  specs:
+    shanti_integration (3.4.6)
+      rails (>= 4.0)
 
 GIT
   remote: git://github.com/thl/active_resource_extensions.git
@@ -113,7 +121,7 @@ GIT
 PATH
   remote: .
   specs:
-    terms_engine (0.5.2)
+    terms_engine (0.5.3)
       jbuilder
       rails (>= 5.2)
 
@@ -175,9 +183,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    annotate (3.0.2)
+    annotate (3.0.3)
       activerecord (>= 3.2, < 7.0)
-      rake (>= 10.4, < 13.0)
+      rake (>= 10.4, < 14.0)
     arel (9.0.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
@@ -321,7 +329,7 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    will_paginate (3.2.0)
+    will_paginate (3.2.1)
     xpath (3.1.0)
       nokogiri (~> 1.8)
 
@@ -343,7 +351,7 @@ DEPENDENCIES
   ffi-icu (= 0.2.0)!
   flare (= 1.2.3)!
   interface_utils (= 2.3.7)!
-  kmaps_engine (= 5.7.7)!
+  kmaps_engine (= 5.7.8)!
   passiverecord (= 0.2)!
   pg
   pry-byebug
@@ -352,8 +360,9 @@ DEPENDENCIES
   resource_controller (= 0.9.2)!
   rspec-rails
   selenium-webdriver
+  shanti_integration (= 3.4.6)!
   spawnling
   terms_engine!
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/app/assets/javascripts/terms_engine/feature_subject_associations_admin.js
+++ b/app/assets/javascripts/terms_engine/feature_subject_associations_admin.js
@@ -1,0 +1,61 @@
+$(document).ready(function() {
+  var branch_id = $('#feature_subject_associations_js_data').data('branchId').replace($('#feature_subject_associations_js_data').data('domain')+'-','')
+  $("#subject_name").kmapsSimpleTypeahead({
+    solr_index: $('#feature_subject_associations_js_data').data('termIndex'),
+    domain: $('#feature_subject_associations_js_data').data('domain'),         //[places, subjects, terms]
+    autocomplete_field: 'name_autocomplete', //the name of the main field to search in
+    additional_filters: ["ancestor_id_gen_path:"+branch_id+"/* OR ancestor_id_gen_path:*/"+branch_id+"/*"],
+    match_criterion: 'contains',  //{contains, begins, exactly}
+    case_sensitive: false,
+    ignore_tree: false,           //This is useful when we want to search in all trees
+  }).bind('typeahead:select',
+        function (ev, sel) {
+        //The return value includes the domain, i.e. subjects-653
+        $("#subject_id").val(sel.doc.id.replace($('#feature_subject_associations_js_data').data('domain')+'-',''));
+        }
+      );
+   var selectAncestorSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#feature_subject_associations_js_data').data('termIndex'),
+    assetIndex: $('#feature_subject_associations_js_data').data('assetIndex'),
+    featureId: $('#feature_subject_associations_js_data').data('featureId'),
+    domain: $('#feature_subject_associations_js_data').data('domain'),
+    perspective: $('#feature_subject_associations_js_data').data('perspective'),
+    tree: $('#feature_subject_associations_js_data').data('tree'), //places
+    featuresPath: $('#feature_subject_associations_js_data').data('featuresPath'),
+  });
+
+    if($('#feature_subject_associations_js_data').data('branchId') != '') {
+    $("#subject_tree_container").kmapsRelationsTree({
+      featureId: $('#feature_subject_associations_js_data').data('branchId'),
+      featuresPath: $('#feature_subject_associations_js_data').data('featuresPath'),
+      termIndex: $('#feature_subject_associations_js_data').data('termIndex'),
+      assetIndex: $('#feature_subject_associations_js_data').data('assetIndex'),
+      perspective: $('#feature_subject_associations_js_data').data('perspective'),
+      tree: $('#feature_subject_associations_js_data').data('tree'), //places
+      domain: $('#feature_subject_associations_js_data').data('domain'), //places
+      extraFields: ["header"],
+      descendants: false,
+      hideAncestors: true,
+      descendantsFullDetail: false,
+      displayPopup: false,
+      solrUtils: selectAncestorSolrUtils,
+      nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+    });
+    $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+      $("#subject_name").val(data.node.title.replace(/(<([^>]+)>)/ig,""));
+      $("#subject_id").val(data.node.key.replace($('#feature_subject_associations_js_data').data('domain')+'-',''));
+    });
+  }
+
+  $("#subject_tree_container").hide();
+
+  $("#js-expand-subject-tree").click(function(event) {
+    event.preventDefault();
+    if($("#js-expand-subject-tree").text().includes('hide')){
+      $("#js-expand-subject-tree").text("Or click here to view subject hierarchy");
+    } else {
+      $("#js-expand-subject-tree").text("Or click here to hide subject hierarchy");
+    }
+    $("#subject_tree_container").toggle();
+  });
+});

--- a/app/services/english_terms_service.rb
+++ b/app/services/english_terms_service.rb
@@ -1,0 +1,76 @@
+class EnglishTermsService
+
+  def initialize(arg = nil)
+    if arg.nil?
+      @terms = Feature.current_roots_by_perspective(Perspective.get_by_code('eng.alpha'))
+    elsif arg.instance_of? Array
+      @terms = arg
+    elsif arg.instance_of? Feature
+      @terms = arg.children.order(:position)
+    end
+  end
+  
+  def terms
+    @terms
+  end
+  
+  def sorted_terms
+    if @sorted_terms.nil?
+      @view ||= View.get_by_code('roman.popular')
+      terms_with_name = terms.collect{|t| [t, t.prioritized_name(@view).name] }
+      sorted_terms_with_name = terms_with_name.sort{ |a,b| a[1].downcase <=> b[1].downcase }
+      @sorted_terms = sorted_terms_with_name.collect(&:first)
+    end
+    @sorted_terms
+  end
+  
+  def names
+    if @names.nil?
+      @view ||= View.get_by_code('roman.popular')
+      @names = terms.collect{|t| t.prioritized_name(@view).name}
+    end
+    @names
+  end
+  
+  def trunk_for(name)
+    pos = position_for(name)
+    pos.nil? ? terms[terms.size-1] : terms[pos]
+  end
+    
+  def position_for(name)
+    pos = names.find_index{|n| (n.downcase <=> name.downcase) >= 0}
+    pos.nil? || pos==0 ? nil : pos - 1
+  end
+  
+  def self.recursive_trunk_for(name)
+    letters = EnglishTermsService.new
+    letter = letters.trunk_for(name)
+    return nil if letter.nil?
+    #TODO: We need to handle the case when there are no items in the letter
+    EnglishTermsService.new(letter).trunk_for(name)
+  end
+  
+  def reposition
+    sorted = self.sorted_terms
+    sorted.each_index { |i| sorted[i].update_attribute(:position, i+1) }
+  end
+
+  def self.add_term(subject_id, term_name)
+    if subject_id == Feature::ENG_LETTER_SUBJECT_ID
+      f = Feature.search_by_phoneme(term_name, Feature::ENG_LETTER_SUBJECT_ID)
+    else
+      f = Feature.search_by_excluding_phoneme(term_name, Feature::ENG_PHONEME_SUBJECT_ID, Feature::ENG_LETTER_SUBJECT_ID)
+    end
+    return f if !f.nil?
+    f = Feature.create!(fid: Feature.generate_pid, is_public: 1)
+    @@english_language ||= Language.get_by_code('eng')
+    @@latin_script ||= WritingSystem.get_by_code('latin')
+    
+    names = f.names
+    # TODO: Validate that the name was created succesfully or notify the user
+    english_name = names.create!(skip_update: true, name: term_name, position: 0, writing_system: @@latin_script, language: @@english_language, is_primary_for_romanization: true)
+    # TODO: Validate that the subject_term_association was created succesfully or notify the user
+    a = f.subject_term_associations.create(subject_id: subject_id, branch_id: Feature::ENG_PHONEME_SUBJECT_ID)
+    return f
+  end
+end

--- a/app/services/tibetan_terms_service.rb
+++ b/app/services/tibetan_terms_service.rb
@@ -1,7 +1,7 @@
-class TermsService
+class TibetanTermsService
   def initialize(arg = nil)
     if arg.nil?
-      @terms = Feature.roots.order(:position)
+      @terms = Feature.current_roots_by_perspective(Perspective.get_by_code('tib.alpha'))
     elsif arg.instance_of? Array
       @terms = arg
     elsif arg.instance_of? Feature
@@ -42,10 +42,10 @@ class TermsService
   end
   
   def self.recursive_trunk_for(name)
-    letters = TermsService.new
+    letters = TibetanTermsService.new
     letter = letters.trunk_for(name)
     return nil if letter.nil?
-    TermsService.new(letter).trunk_for(name)
+    TibetanTermsService.new(letter).trunk_for(name)
   end
   
   def reposition
@@ -96,9 +96,7 @@ class TermsService
         relation = FeatureNameRelation.create!(skip_update: true, parent_node: tibetan_name || wylie_name, child_node: phonetic_name, is_phonetic: 1, is_orthographic: 0, is_translation: 0, is_alt_spelling: 0, phonetic_system: @@thl_phonetic)
       end
     end
-    if f.subject_term_associations.empty?
-      a = f.subject_term_associations.create(subject_id: level_subject_id, branch_id: Feature::PHONEME_SUBJECT_ID)
-    end
+    a = f.subject_term_associations.create(subject_id: level_subject_id, branch_id: Feature::BOD_PHONEME_SUBJECT_ID)
     return f
   end
 end

--- a/app/views/admin/features/new.html.erb
+++ b/app/views/admin/features/new.html.erb
@@ -5,8 +5,10 @@
   </div>
   <div class="panel-body">
     <% url = admin_features_path
-    if current_perspective.code == "tib.alpha"
+    if current_perspective.code == 'tib.alpha'
       url = create_tibetan_term_admin_features_path
+    elsif current_perspective.code == 'eng.alpha'
+      url = create_english_term_admin_features_path
     end %>
     <%= form_with(model: object, url: url, local: true) do |form| %>
       <div class="term-form-fields">
@@ -25,18 +27,65 @@
           </div>
         <% end %>
 
-        <% if current_perspective.code == "tib.alpha" %>
+        <% if current_perspective.code == 'tib.alpha' %>
           <fieldset>
             <legend><%= ts(:for, what: t('information.general'), whom: Feature.model_name.human.titleize) %></legend>
             <div class="row">
               <%= form.label :term_name, Feature.model_name.human.titleize %>
               <br/>
               <br/>
-              <%= text_field_tag :term_name, :post, { placeholder: t('snippet.feature.name.unicode_insert_request'), value: @name, id: :term_name } %>
+              <%= text_field_tag :term_name, :post, { placeholder: t('snippet.feature.name.unicode_insert_bod_request'), value: @name, id: :term_name } %>
               <%=  link_to ts('cancel.this'), admin_features_path(object) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
               <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
             </div>
           </fieldset>
+        <% elsif current_perspective.code == 'eng.alpha' %>
+          <fieldset>
+            <legend><%= ts(:for, what: t('information.general'), whom: Feature.model_name.human.titleize) %></legend>
+            <div class="row">
+              <%= form.label :term_name, Feature.model_name.human.titleize %>
+              <%= text_field_tag :term_name, :post, { placeholder: t('snippet.feature.name.unicode_insert_eng_request'), value: @name, id: :term_name } %>
+            </div>
+            <div class="row" id="subject_container">
+              <%= form.label :subject_name, SubjectsIntegration::Feature.human_name.titleize.s %>
+              <br/>
+              <br/>
+              <%= form.fields_for :subject_term_associations do |subject_term_association_form| %>
+                <%= subject_term_association_form.hidden_field :subject_id, id: :subject_id %>
+                <% if !subject_term_association_form.object.nil? && !subject_term_association_form.object.id.nil? %>
+                  <%= subject_term_association_form.hidden_field :id %>
+                <% end %>
+                <%= subject_term_association_form.hidden_field :branch_id, id: :branch_id %>
+                <%= subject_term_association_form.hidden_field :_destroy %>
+                <p>Search by name</p>
+                <%
+                    subject_name = ''
+                if !subject_term_association_form.object.nil? && !subject_term_association_object.subject.blank?
+                  subject_name = subject_term_association_form.object.subject['header']
+                end
+              %>
+            <%= text_field_tag :subject_name, :post, { placeholder: 'Search by subject name', value: subject_name } %>
+            <a href="#" id="js-expand-subject-tree">Or click here to view subject hierarchy</a>
+            <div id="subject_tree_container"></div>
+            <% end %>
+            </div>
+            <div class="row">
+              <%=  link_to ts('cancel.this'), admin_features_path(object) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+              <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+            </div>
+          </fieldset>
+          <%= content_tag :div, '', id: 'feature_subject_associations_js_data', data: {
+           term_index: Feature.config.url,
+           asset_index: Flare.config.asset_url,
+           feature_id: '',
+           domain: 'subjects',
+           perspective: 'gen',
+           tree: 'subjects',
+           features_path: new_admin_feature_path(parent_id: '%%ID%%'),
+           mandala_path: 'https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs',
+           branch_id: "subjects-#{Feature::ENG_PHONEME_SUBJECT_ID}",
+          } %>
+          <%= javascript_include_tag 'terms_engine/feature_subject_associations_admin' %>
         <% else %>
           <%=   render partial: 'form_fields', locals: {f: form} %>
           <%=   fields_for @name do |name_fields| %>

--- a/app/views/features/_subjects.html.erb
+++ b/app/views/features/_subjects.html.erb
@@ -1,4 +1,6 @@
 <% for branch_id in associations.select(:branch_id).distinct.collect(&:branch_id)
      branch = SubjectsIntegration::Feature.flare_search(branch_id) %>
-   <dt><%= branch['header'] %>:</dt><dd class="related_subject"> <%= associations.where(branch_id: branch_id).collect{ |a| "#{link_to a.subject['header'], SubjectsIntegration::Feature.get_url(a.subject_id)}#{feature_assets_popup("subjects-"+a.subject_id.to_s)}#{note_popup_link_for(a)}#{time_units_for(a)}" }.join(', ').html_safe %></dd>
+   <% if branch %>
+     <dt><%= branch['header'] %>:</dt><dd class="related_subject"> <%= associations.where(branch_id: branch_id).collect{ |a| "#{link_to a.subject['header'], SubjectsIntegration::Feature.get_url(a.subject_id)}#{feature_assets_popup("subjects-"+a.subject_id.to_s)}#{note_popup_link_for(a)}#{time_units_for(a)}" }.join(', ').html_safe %></dd>
+  <% end %>
  <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,6 +4,7 @@ Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js',
                                                    'terms_engine/subject_term_associations_admin.js',
                                                    'terms_engine/definition_subject_associations_admin.js',
                                                    'terms_engine/etymology_type_associations_admin.js',
+                                                   'terms_engine/feature_subject_associations_admin.js',
                                                    'terms_engine/etymology_subject_associations_admin.js',
                                                    'terms_engine/relation_subject_associations_admin.js',
                                                    ])

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -27,7 +27,8 @@ bo:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
-                unicode_insert_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_bod_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_eng_request: 'Insert term in English Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -27,7 +27,8 @@ dz:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
-                unicode_insert_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_bod_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_eng_request: 'Insert term in English Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -27,7 +27,8 @@ en:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
-                unicode_insert_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_bod_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_eng_request: 'Insert term in English Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -27,7 +27,8 @@ zh:
             name:
                 drag_priority: 'Click a name and drag to a new location to indicate the priority between the different names. This priority sequencing of names will be used to decide which name to show on the navigational tree, and other contexts. Thus if there are two version of popular romanization of a name, for example, the prioritized one will be chosen; of if there are two alternative names, the prioritized one will be displayed; and so forth.'
                 not_related: 'Sorry, this term does not currently have any related terms.'
-                unicode_insert_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_bod_request: 'Insert term in Tibetan Unicode'
+                unicode_insert_eng_request: 'Insert term in English Unicode'
             not:
                 contains: 'This term does not contain other terms.'
                 found: 'Sorry, this term couldn''t be found. Please use the menu on the right to search or browse for a term.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     end
     resources :features do
       post :create_tibetan_term, on: :collection
+      post :create_english_term, on: :collection
       resources :definitions do #, only: [:index, :show]
         get :locate_for_relation, on: :member
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_18_074518) do
+ActiveRecord::Schema.define(version: 2019_10_10_204258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,11 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["collection_id", "feature_id", "perspective_id"], name: "affiliations_on_dependencies", unique: true
+  end
+
+  create_table "authors_definitions", id: false, force: :cascade do |t|
+    t.bigint "author_id", null: false
+    t.bigint "definition_id", null: false
   end
 
   create_table "authors_descriptions", id: false, force: :cascade do |t|
@@ -188,9 +193,9 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
   end
 
   create_table "etymologies", force: :cascade do |t|
-    t.integer "context_id"
-    t.string "context_type"
-    t.text "content"
+    t.integer "context_id", null: false
+    t.string "context_type", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -202,15 +207,6 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["etymology_id"], name: "index_etymology_subject_associations_on_etymology_id"
-  end
-
-  create_table "etymology_type_associations", force: :cascade do |t|
-    t.bigint "etymology_id", null: false
-    t.integer "subject_id"
-    t.integer "branch_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["etymology_id"], name: "index_etymology_type_associations_on_etymology_id"
   end
 
   create_table "external_pictures", force: :cascade do |t|
@@ -274,6 +270,7 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
     t.string "code", null: false
     t.boolean "is_hierarchical", default: false, null: false
     t.string "asymmetric_code"
+    t.integer "branch_id"
   end
 
   create_table "feature_relations", force: :cascade do |t|
@@ -350,9 +347,9 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
   end
 
   create_table "model_sentences", force: :cascade do |t|
-    t.integer "context_id"
-    t.string "context_type"
-    t.text "content"
+    t.integer "context_id", null: false
+    t.string "context_type", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -387,9 +384,9 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
   end
 
   create_table "passages", force: :cascade do |t|
-    t.integer "context_id"
-    t.string "context_type"
-    t.text "content"
+    t.integer "context_id", null: false
+    t.string "context_type", null: false
+    t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -427,6 +424,15 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
     t.datetime "updated_at", null: false
     t.integer "dialect_id"
     t.index ["feature_id"], name: "index_recordings_on_feature_id"
+  end
+
+  create_table "relation_subject_associations", force: :cascade do |t|
+    t.bigint "feature_relation_id", null: false
+    t.integer "subject_id", null: false
+    t.integer "branch_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_relation_id"], name: "index_relation_subject_associations_on_feature_relation_id"
   end
 
   create_table "roles", force: :cascade do |t|
@@ -530,6 +536,6 @@ ActiveRecord::Schema.define(version: 2018_09_18_074518) do
 
   add_foreign_key "definition_subject_associations", "definitions"
   add_foreign_key "etymology_subject_associations", "etymologies"
-  add_foreign_key "etymology_type_associations", "etymologies"
   add_foreign_key "recordings", "features"
+  add_foreign_key "relation_subject_associations", "feature_relations"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,10 +6,14 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-Perspective.update_or_create name: 'Tibetan Alphabetical', code: 'tib.alpha', is_public: true
+[ { name: 'Tibetan Alphabetical', code: 'tib.alpha', is_public: true },
+  { name: 'English Alphabetical', code: 'eng.alpha', is_public: true }
+].each { |p| Perspective.update_or_create(p) }
 
 [ { label: 'is beginning of', asymmetric_label: 'starts with', is_hierarchical: true,
     code: 'is.beginning.of', asymmetric_code: 'begins.with', is_symmetric: false },
   { label: 'heads', asymmetric_label: 'is headed by', is_hierarchical: true,
-    code: 'heads', asymmetric_code: 'is.headed.by', is_symmetric: false }
+    code: 'heads', asymmetric_code: 'is.headed.by', is_symmetric: false },
+  { label: 'has a conjugation', asymmetric_label: 'is a conjugation of', is_hierarchical: false,
+    code: 'is.a.conjugation.of', asymmetric_code: 'has.as.a.conjugation', is_symmetric: false }
 ].each{ |a| FeatureRelationType.update_or_create(a) }

--- a/lib/terms_engine/engine.rb
+++ b/lib/terms_engine/engine.rb
@@ -5,12 +5,13 @@ module TermsEngine
       require 'terms_engine/extension/admin_features_controller'
       require 'terms_engine/extension/admin_feature_relations_controller'
       require 'terms_engine/extension/admin_feature_relation_types_controller'
+      require 'terms_engine/extension/citations_controller'
       require 'terms_engine/extension/feature_controller'
       require 'terms_engine/extension/feature_model'
       require 'terms_engine/extension/feature_relation_model'
       require 'terms_engine/extension/feature_relation_type_model'
       require 'terms_engine/extension/illustration_model'
-      require 'terms_engine/extension/citations_controller'
+      require 'terms_engine/extension/perspective_model'
       require 'terms_engine/has_model_sentences'
 
       Feature.send :include, TermsEngine::Extension::FeatureModel
@@ -22,6 +23,7 @@ module TermsEngine
       Admin::FeaturesController.send :include, TermsEngine::Extension::AdminFeaturesController
       Admin::FeatureRelationsController.send :include, TermsEngine::Extension::AdminFeatureRelationsController
       Admin::FeatureRelationTypesController.send :include, TermsEngine::Extension::AdminFeatureRelationTypesController
+      Perspective.send :include, TermsEngine::Extension::PerspectiveModel
     end
 
     config.generators do |g|

--- a/lib/terms_engine/extension/admin_features_controller.rb
+++ b/lib/terms_engine/extension/admin_features_controller.rb
@@ -4,27 +4,53 @@ module TermsEngine
       extend ActiveSupport::Concern
 
       included do
+        # We want to remove the default action created in KmapsEngine
         new_action.wants.html {}
+      end
+
+      def create_english_term
+        # TODO: Create english_cleanup to remove leading and trailing spaces
+        current_entry = params[:term_name].chomp
+        @current_term = Feature.search_english_term(current_entry)
+        if @current_term.nil?
+          eng_alpha = Perspective.get_by_code('eng.alpha')
+          relation_type = FeatureRelationType.get_by_code('is.beginning.of')
+          parent = EnglishTermsService.new.trunk_for(current_entry)
+          subject_id = params[:feature][:subject_term_associations][:subject_id]
+          @current_term = EnglishTermsService.add_term(subject_id, current_entry)
+          @object = @current_term
+          FeatureRelation.create!(child_node: @current_term, parent_node: parent, perspective: eng_alpha, feature_relation_type: relation_type)
+          ts = EnglishTermsService.new(parent)
+          ts.reposition
+          @name = nil
+        else
+          @object = Feature.new
+          object.errors.add :base, t('feature.errors.term_exists')
+          @name = current_entry
+        end
+        respond_to do |format|
+          format.html { @name.nil? ? redirect_to(admin_feature_url(object.fid)) : render('admin/features/new') }
+        end
       end
 
       def create_tibetan_term
         current_entry = params[:term_name].tibetan_cleanup
-        @current_term = Feature.search_expression(current_entry)
+        @current_term = Feature.search_bod_expression(current_entry)
         if @current_term.nil?
           tib_alpha = Perspective.get_by_code('tib.alpha')
           relation_type = FeatureRelationType.get_by_code('is.beginning.of')
-          parent = TermsService.recursive_trunk_for(current_entry)
+          parent = TibetanTermsService.recursive_trunk_for(current_entry)
           if parent.ancestors_by_perspective(tib_alpha).count != 2
             @object = Feature.new
             object.errors.add :base, "There is a problem for term: #{current_entry} with calculated parent: #{parent.pid} in herarchy. Skipping term creation."
             @name = current_entry
           else
-            wylie = TermsService.get_wylie(current_entry)
-            phonetic = TermsService.get_phonetic(current_entry)
-            @current_term = TermsService.add_term(Feature::EXPRESSION_SUBJECT_ID, current_entry, wylie, phonetic)
+            wylie = TibetanTermsService.get_wylie(current_entry)
+            phonetic = TibetanTermsService.get_phonetic(current_entry)
+            @current_term = TibetanTermsService.add_term(Feature::BOD_EXPRESSION_SUBJECT_ID, current_entry, wylie, phonetic)
             @object = @current_term
             FeatureRelation.create!(child_node: @current_term, parent_node: parent, perspective: tib_alpha, feature_relation_type: relation_type)
-            ts = TermsService.new(parent)
+            ts = TibetanTermsService.new(parent)
             ts.reposition
             @name = nil
           end

--- a/lib/terms_engine/extension/perspective_model.rb
+++ b/lib/terms_engine/extension/perspective_model.rb
@@ -1,0 +1,24 @@
+module TermsEngine
+  module Extension
+    module PerspectiveModel
+      extend ActiveSupport::Concern
+
+      included do
+      end
+
+      module ClassMethods
+
+        def get_by_language_code(code)
+          perspective_code = Rails.cache.fetch("perspective/language/#{code}", :expires_in => 1.day) do
+            case code
+            when 'eng' then 'eng.alpha'
+            when 'bod' then 'tib.alpha'
+            else nil
+            end
+          end
+          perspective_code.nil? ? nil : Perspective.get_by_code(perspective_code)
+        end
+      end
+    end
+  end
+end

--- a/lib/terms_engine/flare_utils.rb
+++ b/lib/terms_engine/flare_utils.rb
@@ -36,7 +36,7 @@ module TermsEngine
         query_array = []
         query_array << "level_tib.alpha_i:#{level}" if !level.blank?
         query_array << "ancestor_ids_tib.alpha:#{letter}" if !letter.blank?
-        query_array << "associated_subject_#{Feature::PHONEME_SUBJECT_ID}_ls:#{phoneme}" if !phoneme.blank?
+        query_array << "associated_subject_#{Feature::BOD_PHONEME_SUBJECT_ID}_ls:#{phoneme}" if !phoneme.blank?
         query = query_array.join(' AND ')
         num_found = Feature.search_by(query)['numFound']
         resp = Feature.search_by(query, fl: 'uid', rows: num_found)['docs']

--- a/lib/terms_engine/import/feature_importation.rb
+++ b/lib/terms_engine/import/feature_importation.rb
@@ -132,17 +132,17 @@ module TermsEngine
           phonetic_str = name_str if phonetic_str.blank?
         end
       end
-      self.feature = Feature.search_expression(tibetan_str)
+      self.feature = Feature.search_bod_expression(tibetan_str)
       if self.feature.nil?
         self.log.debug "Adding new term #{tibetan_str}"
-        parent = TermsService.recursive_trunk_for(tibetan_str)
+        parent = TibetanTermsService.recursive_trunk_for(tibetan_str)
         if parent.ancestors_by_perspective(@tib_alpha).count != 2
           self.say "There is a problem for term: #{current_entry} with calculated parent: #{parent.pid} in herarchy. Skipping term creation."
           return nil
         end
-        self.feature = TermsService.add_term(Feature::EXPRESSION_SUBJECT_ID, tibetan_str, wylie_str, phonetic_str)
+        self.feature = TibetanTermsService.add_term(Feature::BOD_EXPRESSION_SUBJECT_ID, tibetan_str, wylie_str, phonetic_str)
         FeatureRelation.create!(child_node: self.feature, parent_node: parent, perspective: @tib_alpha, feature_relation_type: @relation_type)
-        ts = TermsService.new(parent)
+        ts = TibetanTermsService.new(parent)
         ts.reposition
         self.feature.reload
         position = self.feature.position

--- a/lib/terms_engine/version.rb
+++ b/lib/terms_engine/version.rb
@@ -1,3 +1,3 @@
 module TermsEngine
-  VERSION = '0.5.2'
+  VERSION = '0.5.3'
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_082327) do
+ActiveRecord::Schema.define(version: 2019_10_10_175711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -265,6 +265,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_082327) do
     t.string "code", null: false
     t.boolean "is_hierarchical", default: false, null: false
     t.string "asymmetric_code"
+    t.integer "branch_id"
   end
 
   create_table "feature_relations", force: :cascade do |t|
@@ -420,6 +421,15 @@ ActiveRecord::Schema.define(version: 2018_09_05_082327) do
     t.index ["feature_id"], name: "index_recordings_on_feature_id"
   end
 
+  create_table "relation_subject_associations", force: :cascade do |t|
+    t.bigint "feature_relation_id", null: false
+    t.integer "subject_id", null: false
+    t.integer "branch_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_relation_id"], name: "index_relation_subject_associations_on_feature_relation_id"
+  end
+
   create_table "roles", force: :cascade do |t|
     t.string "title", limit: 20, null: false
     t.text "description"
@@ -522,4 +532,5 @@ ActiveRecord::Schema.define(version: 2018_09_05_082327) do
   add_foreign_key "definition_subject_associations", "definitions"
   add_foreign_key "etymology_subject_associations", "etymologies"
   add_foreign_key "recordings", "features"
+  add_foreign_key "relation_subject_associations", "feature_relations"
 end

--- a/spec/unit/handling_english_letters_spec.rb
+++ b/spec/unit/handling_english_letters_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+require 'rake'
+Rails.application.load_tasks
+
+RSpec.describe EnglishTermsService do
+  describe "Handling English letters" do
+    before(:all) do
+      # Needed to populate languages, writing systems, etc.
+      Rake::Task['kmaps_engine:db:seed'].invoke
+      # Needed to populate perspective
+      Rake::Task['terms_engine:db:seed'].invoke
+      
+      # Adding letters randomly in order to test sorting in DB
+      r = Random.new
+      ('A'..'Z').each.sort_by { |l| r.rand(100) }.each { |letter| EnglishTermsService.add_term(Feature::ENG_LETTER_SUBJECT_ID, letter) }
+    end
+
+    context "Sorting" do
+      it "Sorts letters" do
+        es = EnglishTermsService.new
+        expected = ('A'..'Z').to_a
+        v = View.get_by_code('roman.popular')
+        sorted = es.sorted_terms.collect{|f| f.prioritized_name(v).name }
+        expect(sorted).to eq(expected)
+      end
+      
+      it "Updates position for letters" do
+        es = EnglishTermsService.new
+        es.reposition
+        expected = ('A'..'Z').to_a
+        v = View.get_by_code('roman.popular')
+        eng_alpha = Perspective.get_by_code('eng.alpha')
+        sorted = Feature.current_roots_by_perspective(eng_alpha).collect{|f| f.prioritized_name(v).name }
+        expect(sorted).to eq(expected)
+      end
+    end
+  end
+end
+
+

--- a/spec/unit/handling_english_phrases_spec.rb
+++ b/spec/unit/handling_english_phrases_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+require 'rake'
+Rails.application.load_tasks
+
+RSpec.describe EnglishTermsService do
+  describe "Handling English phrases" do
+    before(:all) do
+      # Needed to populate languages, writing systems, etc.
+      Rake::Task['kmaps_engine:db:seed'].invoke
+      
+      # Needed to populate perspective
+      Rake::Task['terms_engine:db:seed'].invoke
+      # Preparing letters
+      ('A'..'Z').each { |letter| EnglishTermsService.add_term(Feature::ENG_LETTER_SUBJECT_ID, letter) }
+      es = EnglishTermsService.new
+      es.reposition
+      second_level_seed_data = ['Analytic mind', 'Abstract thought', 'Animal insticts', 'Anomaly', 'Absent minded', 'Acquired taste']
+      eng_alpha = Perspective.get_by_code('eng.alpha')
+      relation_type = FeatureRelationType.get_by_code('is.beginning.of')
+      a = Feature.current_roots_by_perspective(eng_alpha).first
+      r = Random.new
+      second_level_seed_data.sort_by{ |w| r.rand(10) }.each do |word|
+        subject_id = word.split(' ').size > 1 ? Feature::ENG_PHRASE_SUBJECT_ID : Feature::ENG_WORD_SUBJECT_ID
+        term = EnglishTermsService.add_term(subject_id, word)
+        FeatureRelation.create!(child_node: term, parent_node: a, perspective: eng_alpha, feature_relation_type: relation_type) if FeatureRelation.where(child_node: term, parent_node: a).first.nil?
+      end
+    end
+    
+    context "Positioning phrases among root letters" do
+      it "Identifies root letter position" do
+        es = EnglishTermsService.new
+        expect(es.position_for('Generosity')).to eq(6)
+        expect(es.position_for('Virtue')).to eq(21)
+        expect(es.position_for('Renunciation')).to eq(17)
+        expect(es.position_for('Wisdom')).to eq(22)
+        expect(es.position_for('Effort')).to eq(4)
+        expect(es.position_for('Patience')).to eq(15)
+        expect(es.position_for('Honesty')).to eq(7)
+        expect(es.position_for('Determination')).to eq(3)
+        expect(es.position_for('Loving-kindness')).to eq(11)
+        expect(es.position_for('Equanimity')).to eq(4)
+      end
+
+      it "Identifies root letter" do
+        es = EnglishTermsService.new
+        v = View.get_by_code('roman.popular')
+        expect(es.trunk_for('Generosity').prioritized_name(v).name).to eq('G')
+        expect(es.trunk_for('Ethics').prioritized_name(v).name).to eq('E')
+        expect(es.trunk_for('Patience').prioritized_name(v).name).to eq('P')
+        expect(es.trunk_for('Effort').prioritized_name(v).name).to eq('E')
+        expect(es.trunk_for('Concentration').prioritized_name(v).name).to eq('C')
+        expect(es.trunk_for('Wisdom').prioritized_name(v).name).to eq('W')
+      end
+    end
+    
+    context "Second level phrases" do
+      it "Sorts phrases" do
+        eng_alpha = Perspective.get_by_code('eng.alpha')
+        a = Feature.current_roots_by_perspective(eng_alpha).first
+        es = EnglishTermsService.new(a)
+        expected = ['Absent minded', 'Abstract thought', 'Acquired taste', 'Analytic mind', 'Animal insticts', 'Anomaly']
+        v = View.get_by_code('roman.popular')
+        sorted = es.sorted_terms.collect{|f| f.prioritized_name(v).name }
+        expect(sorted).to eq(expected)
+      end
+      
+      it "Updates position for phrases" do
+        eng_alpha = Perspective.get_by_code('eng.alpha')
+        a = Feature.current_roots_by_perspective(eng_alpha).first
+        es = EnglishTermsService.new(a)
+        es.reposition
+        expected = ['Absent minded', 'Abstract thought', 'Acquired taste', 'Analytic mind', 'Animal insticts', 'Anomaly']
+        v = View.get_by_code('roman.popular')
+        sorted = a.children.order('position').collect{|f| f.prioritized_name(v).name }
+        expect(sorted).to eq(expected)
+      end
+      
+    end
+  end
+end

--- a/spec/unit/handling_tibetan_expressions_spec.rb
+++ b/spec/unit/handling_tibetan_expressions_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'rake'
 Rails.application.load_tasks
 
-RSpec.describe TermsService do
+RSpec.describe TibetanTermsService do
   describe "Handling tibetan expressions" do
     before(:all) do
       # Needed to populate languages, writing systems, etc.
@@ -11,44 +11,44 @@ RSpec.describe TermsService do
       # Needed to populate perspective
       Rake::Task['terms_engine:db:seed'].invoke
       # Preparing letters
-      ComplexScripts::TibetanLetter.all.each { |letter| TermsService.add_term(Feature::LETTER_SUBJECT_ID, letter.unicode, "#{letter.wylie}a") }
-      ts = TermsService.new
+      ComplexScripts::TibetanLetter.all.each { |letter| TibetanTermsService.add_term(Feature::BOD_LETTER_SUBJECT_ID, letter.unicode, "#{letter.wylie}a") }
+      ts = TibetanTermsService.new
       ts.reposition
       second_level_seed_data = ['ཀ', 'ཀི་ཅུ་རམ', 'ཀྱེ་མ', 'དཀའ་བརྩོན', 'རྐྱེན་ངན', 'བརྐྱངས']
-      tib_alpha = Perspective.get_by_code('tib.alpha')
       relation_type = FeatureRelationType.get_by_code('is.beginning.of')
-      ka = Feature.roots.order('position').first
+      tib_alpha = Perspective.get_by_code('tib.alpha')
+      ka = Feature.current_roots_by_perspective(tib_alpha).first
       r = Random.new
       second_level_seed_data.each do |word|
-        term = TermsService.add_term(Feature::PHRASE_SUBJECT_ID, word, nil)
+        term = TibetanTermsService.add_term(Feature::BOD_PHRASE_SUBJECT_ID, word, nil)
         FeatureRelation.create!(child_node: term, parent_node: ka, perspective: tib_alpha, feature_relation_type: relation_type) if FeatureRelation.where(child_node: term, parent_node: ka).first.nil?
       end
-      ts = TermsService.new(ka)
+      ts = TibetanTermsService.new(ka)
       ts.reposition
     end
     
     context "Positioning expressions among phrases" do
       it "Identifies parent phrase" do
         v = View.get_by_code('pri.tib.sec.roman')
-        expect(TermsService.recursive_trunk_for('ཀ་དག').prioritized_name(v).name).to eq('ཀ')
-        expect(TermsService.recursive_trunk_for('ཀོ་གདན').prioritized_name(v).name).to eq('ཀི་ཅུ་རམ')
-        expect(TermsService.recursive_trunk_for('ཀླད་').prioritized_name(v).name).to eq('ཀྱེ་མ')
-        expect(TermsService.recursive_trunk_for('བཀྲ་ཤིས་').prioritized_name(v).name).to eq('དཀའ་བརྩོན')
-        expect(TermsService.recursive_trunk_for('སྐད').prioritized_name(v).name).to eq('རྐྱེན་ངན')
-        expect(TermsService.recursive_trunk_for('བསྐྲོག').prioritized_name(v).name).to eq('བརྐྱངས')
+        expect(TibetanTermsService.recursive_trunk_for('ཀ་དག').prioritized_name(v).name).to eq('ཀ')
+        expect(TibetanTermsService.recursive_trunk_for('ཀོ་གདན').prioritized_name(v).name).to eq('ཀི་ཅུ་རམ')
+        expect(TibetanTermsService.recursive_trunk_for('ཀླད་').prioritized_name(v).name).to eq('ཀྱེ་མ')
+        expect(TibetanTermsService.recursive_trunk_for('བཀྲ་ཤིས་').prioritized_name(v).name).to eq('དཀའ་བརྩོན')
+        expect(TibetanTermsService.recursive_trunk_for('སྐད').prioritized_name(v).name).to eq('རྐྱེན་ངན')
+        expect(TibetanTermsService.recursive_trunk_for('བསྐྲོག').prioritized_name(v).name).to eq('བརྐྱངས')
       end
     end
     
     context "Adding expressions" do
       it "Identifies right parent" do
         expression_to_be_added = 'བཀྲ་ཤིས་'
-        parent = TermsService.recursive_trunk_for(expression_to_be_added)
-        term = TermsService.add_term(Feature::EXPRESSION_SUBJECT_ID, expression_to_be_added, nil)
+        parent = TibetanTermsService.recursive_trunk_for(expression_to_be_added)
+        term = TibetanTermsService.add_term(Feature::BOD_EXPRESSION_SUBJECT_ID, expression_to_be_added, nil)
         tib_alpha = Perspective.get_by_code('tib.alpha')
         relation_type = FeatureRelationType.get_by_code('is.beginning.of')
         FeatureRelation.create!(child_node: term, parent_node: parent, perspective: tib_alpha, feature_relation_type: relation_type)
         
-        ts = TermsService.new(parent)
+        ts = TibetanTermsService.new(parent)
         ts.reposition
         term.reload
         expect(term.position).to eq(1)


### PR DESCRIPTION
**Jira Issue:** MANU-6183

**Changes proposed in this pull request:**

 + Add support for multiple projects based on a perspective.
 + Add support for English Language terms.
 + Editorial interface completed for creation of new terms in English based on perspective.
 + Updated JavaScript library to support this.

**Details of the implementation:**

New projects will depend on perspectives. There will be a tree per language, we need to take this into account when reindexing and how all the changes will affect a reindex triggering.
