### PR TITLE
fixed handling of errors in etymology creation.

### DIFF
--- a/lib/terms_engine/version.rb
+++ b/lib/terms_engine/version.rb
@@ -1,3 +1,3 @@
 module TermsEngine
-  VERSION = '0.5.6'
+  VERSION = '0.5.7'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6224

**Changes proposed in this pull request:**

 + app/controllers/admin/etymologies_controller.rb

**Details of the implementation:**

failure.wants.html doesn't seem to work. It is not called even if object.valid? is false. Furthermore, the etymology_type_association does not allow a blank subject_id, so when it is not added and create_etymology_type_association is called, object is now invalid. This would be fine if there were a requirement that an etymology requires an etymology type, but that is not the case and it is assumed elsewhere that etymology type may be blank.