### PR TITLE
Fixes recording form fields markup display - MANU-6502

### DIFF
--- a/app/views/admin/recordings/_form_fields.html.erb
+++ b/app/views/admin/recordings/_form_fields.html.erb
@@ -13,7 +13,7 @@
 <fieldset>
   <legend><%= ts(:for, what: t('information.general'), whom: Recording.model_name.human.titleize) %></legend>
   <div class="row">
-    <%= form.label :dialect_name, ts(:dialect, count: 1).titleize %>
+    <%= form.label :dialect_name, ts(:dialect, count: 1).titleize.html_safe %>
     <br/>
     <br/>
     <%= form.hidden_field :dialect_id, id: :dialect_id %>

--- a/lib/terms_engine/version.rb
+++ b/lib/terms_engine/version.rb
@@ -1,3 +1,3 @@
 module TermsEngine
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6502

**Changes proposed in this pull request:**

 + Fix the form fields partial that displays HTML markup on the editorial interface

**Details of the implementation:**

We needed to mark the content as `html-safe`