### PR TITLE
Remove Capitalization of terms name in breadcrumb - MANU-6250

### DIFF
--- a/app/assets/stylesheets/terms_engine/application.css
+++ b/app/assets/stylesheets/terms_engine/application.css
@@ -79,3 +79,10 @@ body.page-terms .main-col {
  /* box-shadow:none; */
 }
 /* END - fancytree */
+/* breadcrumbs style */
+
+/* We asume that the the phonetic representation will only appear on the second element of the breadcrumb */
+.breadcrumb li:nth-child(2) {
+  text-transform: none;
+}
+/* END - breadcrumbs style */


### PR DESCRIPTION
**Jira Issue:** MANU-6250

**Changes proposed in this pull request:**

 + Remove the capitalisation of the term name that includes Phonetics on breadcrumbs

**Details of the implementation:**

We are assuming that the name will only appear on the second segment of the breadcrumb.