### PR TITLE
MANU-7806 Show priority at end of table and align change priority lin…

### DIFF
--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -53,10 +53,14 @@
       </div>
       <div id="collapseThree" class="panel-collapse collapse">
         <div class="panel-body">
-          <div class="left highlight">
+          <div class="highlight flexContainer">
+            <div>
 <%=         new_item_link [object, :feature_name] %> |
-<%=         link_to ts('clone.into', what: FeatureName.model_name.human(count: :many), whom: t('new.record', what: Feature.model_name.human)), clone_admin_feature_path(object.fid), method: :post, class: 'item-icon-new', title: 'Clone feature names into new feature' %> |
-<%=         edit_item_link(prioritize_feature_names_admin_features_path(object), ts('change.record', what: t('priorit.ization_of', what: FeatureName.model_name.human(count: :many)))) %>
+<%=         link_to ts('clone.into', what: FeatureName.model_name.human(count: :many), whom: t('new.record', what: Feature.model_name.human)), clone_admin_feature_path(object.fid), method: :post, class: 'item-icon-new', title: 'Clone feature names into new feature' %>
+            </div>
+            <div>
+<%=         edit_item_link(prioritize_feature_names_admin_features_path(object), ts('change.record', what: t('priorit.y',))) %>
+            </div>
           </div>
           <br class="clear"/>
 <%=       render partial: 'admin/feature_names/feature_names', locals: { list: object.names } %>


### PR DESCRIPTION
**MANU-7806:** [https://uvaissues.atlassian.net/browse/MANU-7806]

Show priority at end of table and align 'change priority' link above it under Names

This pull request must be merged and deployed at the same time as this pull request to the kmaps_engine gem.
https://github.com/shanti-uva/kmaps_engine/pull/52

This change was requested via this document:
https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit
