### PR TITLE
MANU-7792

### DIFF
--- a/app/views/admin/definitions/_list.html.erb
+++ b/app/views/admin/definitions/_list.html.erb
@@ -11,6 +11,7 @@
        <th class="listActionsCol"></th>
        <th><%= Language.model_name.human.titleize.s %></th>
        <th><%= Definition.model_name.human.titleize.s %></th>
+       <th><%= Citation.model_name.human.titleize.s %></th>
      </tr>
 <%   list.each do |item| %>
      <tr>
@@ -28,6 +29,7 @@
        </td>
        <td><%= item.language.name %></td>
        <td><%= item.snippet.s %></td>
+       <td><%= accordion_citation_list_fieldset(object: item) %></td>
      </tr>
 <%   end %>
    </table>

--- a/app/views/admin/passages/_list.html.erb
+++ b/app/views/admin/passages/_list.html.erb
@@ -5,6 +5,7 @@
      <tr>
        <th class="listActionsCol"></th>
        <th><%= Passage.human_attribute_name('content').s %></th>
+       <th><%= Citation.model_name.human.titleize.s %></th>
      </tr>
 <%   list.each do |item| %>
      <tr>
@@ -14,6 +15,7 @@
          :view_path => polymorphic_path([:admin, item.context, item])) %>
        </td>
        <td><%= item.content.s %></td>
+       <td><%= accordion_citation_list_fieldset(object: item) %></td>
      </tr>
 <%   end %>
    </table>


### PR DESCRIPTION
**MANU-7792:** [[https://uvaissues.atlassian.net/browse/MANU-7792](https://uvaissues.atlassian.net/browse/MANU-7792)]

This shows a column called Citations in the data tables displayed under DEFINITIONS and PASSAGES in the accordion ((kmaps_engine/app/views/admin/features/show).

This pull request depends on data in the following kmaps_engine pull request:
https://github.com/shanti-uva/kmaps_engine/pull/53

These changes were requested in this document: https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit
