### PR TITLE
MANU-7786 MANU-7789 MANU-7777

### DIFF
--- a/app/views/admin/definition_subject_associations/_list.html.erb
+++ b/app/views/admin/definition_subject_associations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{DefinitionSubjectAssociation.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{DefinitionSubjectAssociation.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/definition_subject_associations/_list.html.erb
+++ b/app/views/admin/definition_subject_associations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{DefinitionSubjectAssociation.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/definitions/_list.html.erb
+++ b/app/views/admin/definitions/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-  <%=  empty_collection_message("No #{Definition.model_name.human(count: :many).titleize.s} found.") %>
+  <%=  empty_collection_message("No #{Definition.model_name.human(count: :many).s} found.") %>
 <% else %>
 <%     if @locating_relation %>
           <div class="left highlight">

--- a/app/views/admin/definitions/_list.html.erb
+++ b/app/views/admin/definitions/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+  <%=  empty_collection_message("No #{Definition.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
 <%     if @locating_relation %>
           <div class="left highlight">

--- a/app/views/admin/definitions/_list_legacy.html.erb
+++ b/app/views/admin/definitions/_list_legacy.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{Definition.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{Definition.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/definitions/_list_legacy.html.erb
+++ b/app/views/admin/definitions/_list_legacy.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{Definition.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/etymologies/_list.html.erb
+++ b/app/views/admin/etymologies/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{Etymology.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{Etymology.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/etymologies/_list.html.erb
+++ b/app/views/admin/etymologies/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{Etymology.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/etymology_subject_associations/_list.html.erb
+++ b/app/views/admin/etymology_subject_associations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{EtymologySubjectAssociation.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{EtymologySubjectAssociation.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/etymology_subject_associations/_list.html.erb
+++ b/app/views/admin/etymology_subject_associations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{EtymologySubjectAssociation.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/feature_relation_types/_list.html.erb
+++ b/app/views/admin/feature_relation_types/_list.html.erb
@@ -1,6 +1,6 @@
 <% list = list || [] 
    if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{FeatureRelationType.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>3 unless @collection.nil? %>

--- a/app/views/admin/feature_relation_types/_list.html.erb
+++ b/app/views/admin/feature_relation_types/_list.html.erb
@@ -1,6 +1,6 @@
 <% list = list || [] 
    if list.empty? %>
-<%=  empty_collection_message("No #{FeatureRelationType.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{FeatureRelationType.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>3 unless @collection.nil? %>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -74,6 +74,7 @@
       </div>
       <div id="collapseFour" class="panel-collapse collapse">
         <div class="panel-body">
+          <p><%=  ts 'accordion.caption.help_text' %></p>
 <%=       highlighted_new_item_link [object, :caption] %>
           <br class="clear"/>
 <%=       render partial: 'admin/captions/list', locals: { list: object.captions } %>
@@ -86,6 +87,7 @@
       </div>
       <div id="collapseFive" class="panel-collapse collapse">
         <div class="panel-body">
+          <p><%=  ts 'accordion.summary.help_text' %></p>
 <%=       highlighted_new_item_link [object, :summary] %>
           <br class="clear"/>
 <%=       render partial: 'admin/summaries/list', locals: { list: object.summaries } %>
@@ -98,6 +100,7 @@
       </div>
       <div id="collapseSix" class="panel-collapse collapse">
         <div class="panel-body">
+          <p><%=  ts 'accordion.illustration.help_text', link: "https://confluence.its.virginia.edu/display/KB/Create+Images", link_label: "this guide" %></p>
 <%=       highlighted_new_item_link [object, :illustration] %>
           <br class="clear"/>
 <%=       render partial: 'admin/illustrations/list', locals: { list: object.illustrations } %>
@@ -110,6 +113,7 @@
       </div>
       <div id="collapseSeven" class="panel-collapse collapse">
         <div class="panel-body">
+          <p><%=  ts 'accordion.feature_geo_code.help_text' %></p>
 <%=       highlighted_new_item_link [object, :feature_geo_code] %>
           <br class="clear"/>
 <%=       render partial: 'admin/feature_geo_codes/list', locals: { list: object.geo_codes } %>
@@ -198,6 +202,7 @@
       </div>
       <div id="collapseEleven" class="panel-collapse collapse">
         <div class="panel-body">
+          <p><%=  ts 'accordion.recording.help_text' %></p>
 <%=       highlighted_new_item_link [object, :recording] %>
           <br class="clear"/>
 <%=       render partial: 'admin/recordings/list', locals: { list: object.recordings } %>
@@ -225,6 +230,7 @@
       </div>
       <div id="collapseThirteen" class="panel-collapse collapse">
         <div class="panel-body">
+          <p><%=  ts 'accordion.etymology.help_text' %></p>
 <%=       highlighted_new_item_link [object, :etymology] %>
           <br>
           <br class="clear"/>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -49,7 +49,7 @@
 <% end %>
     <section class="panel panel-default">
       <div class="panel-heading">
-        <h6><a href="#collapseThree" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= FeatureName.model_name.human(count: :many).titleize.s %></a></h6>
+        <h6><a href="#collapseThree" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= ts 'accordion.feature_name.accordion_title' %></a></h6>
       </div>
       <div id="collapseThree" class="panel-collapse collapse">
         <div class="panel-body">

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -100,7 +100,7 @@
       </div>
       <div id="collapseSix" class="panel-collapse collapse">
         <div class="panel-body">
-          <p><%=  ts 'accordion.illustration.help_text', link: "https://confluence.its.virginia.edu/display/KB/Create+Images", link_label: "this guide" %></p>
+          <p><%=  ts 'accordion.illustration.help_text', link: "<a href=\"https://confluence.its.virginia.edu/display/KB/Create+Images\">https://confluence.its.virginia.edu/display/KB/Create+Images</a>" %></p>
 <%=       highlighted_new_item_link [object, :illustration] %>
           <br class="clear"/>
 <%=       render partial: 'admin/illustrations/list', locals: { list: object.illustrations } %>

--- a/app/views/admin/passages/_list.html.erb
+++ b/app/views/admin/passages/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message "No #{Passage.model_name.human.pluralize.titleize} found." %>
+<%=  empty_collection_message "No #{Passage.model_name.human.pluralize} found." %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/recordings/_list.html.erb
+++ b/app/views/admin/recordings/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{Recording.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/recordings/_list.html.erb
+++ b/app/views/admin/recordings/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{Recording.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{Recording.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/subject_term_associations/_list.html.erb
+++ b/app/views/admin/subject_term_associations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{SubjectTermAssociation.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{SubjectTermAssociation.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/subject_term_associations/_list.html.erb
+++ b/app/views/admin/subject_term_associations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{SubjectTermAssociation.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -27,6 +27,9 @@ bo:
             feature_geo_code:
                 one: 'term code'
                 other: 'term codes'
+            feature_name:
+                one: 'representation'
+                other: 'representations'
             feature_name_relation:
                 one: 'term name relation'
                 other: 'term name relations'

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -47,6 +47,8 @@ bo:
             help_text: 'The origin of the term.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        feature_name:
+            accordion_title: 'Transcriptions and Transliterations'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
         recording:

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -50,7 +50,7 @@ bo:
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:
-            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
             help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
         summary:

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -40,3 +40,16 @@ bo:
                 drag_priority: 'Click a term type and drag to a new location to indicate the priority between the different term types. This priority sequencing of term types will be used to decide which term types to show on the navigational tree, and other contexts.'
         info_source_drag_priority: 'Click a dictionary row and drag to a new location to indicate the priority between the different dictionaries. This priority sequencing of dictionaries will be used to sort definitions.'
         search: 'Use the search field above to search for terms.'
+    accordion:
+        caption:
+            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+        etymology:
+            help_text: 'The origin of the term.'
+        feature_geo_code:
+            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        illustration:
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+        recording:
+            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+        summary:
+            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -24,6 +24,9 @@ dz:
             feature:
                 one: 'term'
                 other: 'terms'
+            feature_name:
+                one: 'representation'
+                other: 'representations'
             feature_geo_code:
                 one: 'term code'
                 other: 'term codes'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -50,7 +50,7 @@ dz:
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:
-            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
             help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
         summary:

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -40,3 +40,16 @@ dz:
                 drag_priority: 'Click a term type and drag to a new location to indicate the priority between the different term types. This priority sequencing of term types will be used to decide which term types to show on the navigational tree, and other contexts.'
         info_source_drag_priority: 'Click a dictionary row and drag to a new location to indicate the priority between the different dictionaries. This priority sequencing of dictionaries will be used to sort definitions.'
         search: 'Use the search field above to search for terms.'
+    accordion:
+        caption:
+            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+        etymology:
+            help_text: 'The origin of the term.'
+        feature_geo_code:
+            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        illustration:
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+        recording:
+            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+        summary:
+            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -47,6 +47,8 @@ dz:
             help_text: 'The origin of the term.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        feature_name:
+            accordion_title: 'Transcriptions and Transliterations'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
         recording:

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -27,6 +27,9 @@ en:
             feature_geo_code:
                 one: 'term code'
                 other: 'term codes'
+            feature_name:
+                one: 'representation'
+                other: 'representations'
             feature_name_relation:
                 one: 'term name relation'
                 other: 'term name relations'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -50,7 +50,7 @@ en:
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:
-            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
             help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
         summary:

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -47,6 +47,8 @@ en:
             help_text: 'The origin of the term.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        feature_name:
+            accordion_title: 'Transcriptions and Transliterations'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
         recording:

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -40,3 +40,16 @@ en:
                 drag_priority: 'Click a term type and drag to a new location to indicate the priority between the different term types. This priority sequencing of term types will be used to decide which term types to show on the navigational tree, and other contexts.'
         info_source_drag_priority: 'Click a dictionary row and drag to a new location to indicate the priority between the different dictionaries. This priority sequencing of dictionaries will be used to sort definitions.'
         search: 'Use the search field above to search for terms.'
+    accordion:
+        caption:
+            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+        etymology:
+            help_text: 'The origin of the term.'
+        feature_geo_code:
+            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        illustration:
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+        recording:
+            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+        summary:
+            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -24,9 +24,15 @@ zh:
             feature:
                 one: 'term'
                 other: 'terms'
+            feature_name:
+                one: 'representation'
+                other: 'representations'
             feature_geo_code:
                 one: 'term code'
                 other: 'term codes'
+            feature_name:
+                one: 'representation'
+                other: 'representations'
             feature_name_relation:
                 one: 'term name relation'
                 other: 'term name relations'

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -47,6 +47,8 @@ zh:
             help_text: 'The origin of the term.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        feature_name:
+            accordion_title: 'Transcriptions and Transliterations'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
         recording:

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -50,7 +50,7 @@ zh:
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:
-            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
             help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
         summary:

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -40,3 +40,16 @@ zh:
                 drag_priority: 'Click a term type and drag to a new location to indicate the priority between the different term types. This priority sequencing of term types will be used to decide which term types to show on the navigational tree, and other contexts.'
         info_source_drag_priority: 'Click a dictionary row and drag to a new location to indicate the priority between the different dictionaries. This priority sequencing of dictionaries will be used to sort definitions.'
         search: 'Use the search field above to search for terms.'
+    accordion:
+        caption:
+            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+        etymology:
+            help_text: 'The origin of the term.'
+        feature_geo_code:
+            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+        illustration:
+            help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see <a href=\"%{link}\" target=\"blank\">%{link_label}</a>."
+        recording:
+            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+        summary:
+            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'


### PR DESCRIPTION
**MANU-7786** https://uvaissues.atlassian.net/browse/MANU-7786
 + add help text to summaries, illustrations, term codes, etymologies, recordings, captions.  Help text is added by adding to the config/locales/views files.

**MANU-7789** https://uvaissues.atlassian.net/browse/MANU-7789
 + fixes issue where each accordion section output "No Terms found" instead of "No (section name) found"

**MANU-7777** https://uvaissues.atlassian.net/browse/MANU-7777
 + change NAMES  section header to transcriptions and transliterations. This is set in config/locales/views.
 + change NAMES in edit form etc. to representations. This is set in config/locales/models so it will apply anywhere that model name is used for output.



Please merge and deploy the corresponding KMAPS_ENGINE pull request at the same time as this one:
https://github.com/shanti-uva/kmaps_engine/pull/54

Changes were requested in this doc: https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit
