### PR TITLE
MANU-7794 MANU-7820 MANU-7821 MANU-7838 MANU-7839

### DIFF
--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -140,7 +140,7 @@
         <div class="panel-body">
           <%=       highlighted_new_item_link [object, :subject_term_association], "New #{SubjectTermAssociation.model_name.human}" %>
           <br>
-          <h6>Create Specific Association:</h6>
+          <h6>Some common subject associations to start with:</h6>
 <%=       new_subject_term_associations_links object %>
           <br class="clear"/>
 <%=       render partial: 'admin/subject_term_associations/list', locals: { list: object.subject_term_associations } %>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -134,11 +134,11 @@
 <% end %>
     <section class="panel panel-default">
       <div class="panel-heading">
-        <h6><a href="#collapseTwelve" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= SubjectTermAssociation.model_name.human(count: :many).titleize.s %></a></h6>
+        <h6><a href="#collapseTwelve" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= SubjectTermAssociation.model_name.human(count: :many).s %></a></h6>
       </div>
       <div id="collapseTwelve" class="panel-collapse collapse">
         <div class="panel-body">
-<%=       highlighted_new_item_link [object, :subject_term_association] %>
+          <%=       highlighted_new_item_link [object, :subject_term_association], "New #{SubjectTermAssociation.model_name.human}" %>
           <br>
           <h6>Create Specific Association:</h6>
 <%=       new_subject_term_associations_links object %>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -101,7 +101,7 @@
       <div id="collapseSix" class="panel-collapse collapse">
         <div class="panel-body">
           <p><%=  ts 'accordion.illustration.help_text', link: "<a href=\"https://confluence.its.virginia.edu/display/KB/Create+Images\">https://confluence.its.virginia.edu/display/KB/Create+Images</a>" %></p>
-<%=       highlighted_new_item_link [object, :illustration] %>
+<%=       highlighted_new_item_link [object, :illustration], "New #{Illustration.model_name.human.s}" %>
           <br class="clear"/>
 <%=       render partial: 'admin/illustrations/list', locals: { list: object.illustrations } %>
         </div> <!-- END panel-body -->

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -70,56 +70,34 @@
     </section>
     <section class="panel panel-default">
       <div class="panel-heading">
-        <h6><a href="#collapseFour" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Caption.model_name.human(count: :many).titleize.s %></a></h6>
+        <h6><a href="#collapseThirteen" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Etymology.model_name.human(count: :many).titleize.s %></a></h6>
       </div>
-      <div id="collapseFour" class="panel-collapse collapse">
+      <div id="collapseThirteen" class="panel-collapse collapse">
         <div class="panel-body">
-          <p><%=  ts 'accordion.caption.help_text' %></p>
-<%=       highlighted_new_item_link [object, :caption] %>
+          <p><%=  ts 'accordion.etymology.help_text' %></p>
+<%=       highlighted_new_item_link [object, :etymology] %>
+          <br>
           <br class="clear"/>
-<%=       render partial: 'admin/captions/list', locals: { list: object.captions } %>
+<%=       render partial: 'admin/etymologies/list', locals: { list: object.etymologies } %>
         </div> <!-- END panel-body -->
-      </div> <!-- END collapseFour -->
+      </div> <!-- END collapseTen -->
     </section>
-    <section class="panel panel-default">
+     <section class="panel panel-default">
       <div class="panel-heading">
-        <h6><a href="#collapseFive" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Summary.model_name.human(count: :many).titleize.s %></a></h6>
+        <h6><a href="#collapseTen" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Definition.model_name.human(count: :many).titleize.s %></a></h6>
       </div>
-      <div id="collapseFive" class="panel-collapse collapse">
+      <div id="collapseTen" class="panel-collapse collapse">
         <div class="panel-body">
-          <p><%=  ts 'accordion.summary.help_text' %></p>
-<%=       highlighted_new_item_link [object, :summary] %>
+<%=       highlighted_new_item_link [object, :definition] %>
           <br class="clear"/>
-<%=       render partial: 'admin/summaries/list', locals: { list: object.summaries } %>
+<%=       render partial: 'admin/definitions/list', locals: { list: object.definitions.standard_definitions } %>
+          <legend>
+            <br class="clear"/>Other Dictionaries
+          </legend>
+<%=       render partial: 'admin/definitions/list_legacy', locals: { list: object.definitions.legacy_definitions_by_info_source } %>
+<%=       association_note_list_fieldset(Description.name) %>
         </div> <!-- END panel-body -->
-      </div> <!-- END collapseFive -->
-    </section>
-    <section class="panel panel-default">
-      <div class="panel-heading">
-        <h6><a href="#collapseSix" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Illustration.model_name.human(count: :many).titleize.s %></a></h6>
-      </div>
-      <div id="collapseSix" class="panel-collapse collapse">
-        <div class="panel-body">
-          <p><%=  ts 'accordion.illustration.help_text', link: "<a href=\"https://confluence.its.virginia.edu/display/KB/Create+Images\">https://confluence.its.virginia.edu/display/KB/Create+Images</a>" %></p>
-<%=       highlighted_new_item_link [object, :illustration], "New #{Illustration.model_name.human.s}" %>
-          <br class="clear"/>
-<%=       render partial: 'admin/illustrations/list', locals: { list: object.illustrations } %>
-        </div> <!-- END panel-body -->
-      </div> <!-- END collapseSix -->
-    </section>
-    <section class="panel panel-default">
-      <div class="panel-heading">
-        <h6><a href="#collapseSeven" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= FeatureGeoCode.model_name.human(count: :many).titleize.s %></a></h6>
-      </div>
-      <div id="collapseSeven" class="panel-collapse collapse">
-        <div class="panel-body">
-          <p><%=  ts 'accordion.feature_geo_code.help_text' %></p>
-<%=       highlighted_new_item_link [object, :feature_geo_code] %>
-          <br class="clear"/>
-<%=       render partial: 'admin/feature_geo_codes/list', locals: { list: object.geo_codes } %>
-<%=       association_note_list_fieldset(FeatureGeoCode.name) %>
-        </div> <!-- END panel-body -->
-      </div> <!-- END collapseSeven -->
+      </div> <!-- END collapseTen -->
     </section>
 <% if current_user.admin? || object.authorized_for_descendants?(current_user) %>
     <section class="panel panel-default">
@@ -156,61 +134,6 @@
 <% end %>
     <section class="panel panel-default">
       <div class="panel-heading">
-        <h6><a href="#collapseNine" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Description.model_name.human(count: :many).titleize.s %></a></h6>
-      </div>
-      <div id="collapseNine" class="panel-collapse collapse">
-        <div class="panel-body">
-<%=       highlighted_new_item_link [object, :description] %>
-          <br class="clear"/>
-<%=       render partial: 'admin/descriptions/descriptions_list', locals: { list: object.descriptions.order('is_primary DESC, title') } %>
-<%=       association_note_list_fieldset(Description.name) %>
-        </div> <!-- END panel-body -->
-      </div> <!-- END collapseNine -->
-    </section>
-    <section class="panel panel-default">
-      <div class="panel-heading">
-        <h6><a href="#collapseTen" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Definition.model_name.human(count: :many).titleize.s %></a></h6>
-      </div>
-      <div id="collapseTen" class="panel-collapse collapse">
-        <div class="panel-body">
-<%=       highlighted_new_item_link [object, :definition] %>
-          <br class="clear"/>
-<%=       render partial: 'admin/definitions/list', locals: { list: object.definitions.standard_definitions } %>
-          <legend>
-            <br class="clear"/>Other Dictionaries
-          </legend>
-<%=       render partial: 'admin/definitions/list_legacy', locals: { list: object.definitions.legacy_definitions_by_info_source } %>
-<%=       association_note_list_fieldset(Description.name) %>
-        </div> <!-- END panel-body -->
-      </div> <!-- END collapseTen -->
-    </section>
-    <section class="panel panel-default">
-      <div class="panel-heading">
-        <h6><a href="#collapsePassages" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Passage.model_name.human(count: :many).titleize.s %></a></h6>
-      </div>
-      <div id="collapsePassages" class="panel-collapse collapse">
-        <div class="panel-body">
-<%=       highlighted_new_item_link [object, :passage] %>
-          <br class="clear"/>
-<%=       render partial: 'admin/passages/list', locals: { list: object.passages.order('id DESC') } %>
-        </div> <!-- END panel-body -->
-      </div> <!-- END collapseTen -->
-    </section>
-    <section class="panel panel-default">
-      <div class="panel-heading">
-        <h6><a href="#collapseEleven" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Recording.model_name.human(count: :many).titleize.s %></a></h6>
-      </div>
-      <div id="collapseEleven" class="panel-collapse collapse">
-        <div class="panel-body">
-          <p><%=  ts 'accordion.recording.help_text' %></p>
-<%=       highlighted_new_item_link [object, :recording] %>
-          <br class="clear"/>
-<%=       render partial: 'admin/recordings/list', locals: { list: object.recordings } %>
-        </div> <!-- END panel-body -->
-      </div> <!-- END collapseTen -->
-    </section>
-    <section class="panel panel-default">
-      <div class="panel-heading">
         <h6><a href="#collapseTwelve" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= SubjectTermAssociation.model_name.human(count: :many).titleize.s %></a></h6>
       </div>
       <div id="collapseTwelve" class="panel-collapse collapse">
@@ -226,17 +149,97 @@
     </section>
     <section class="panel panel-default">
       <div class="panel-heading">
-        <h6><a href="#collapseThirteen" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Etymology.model_name.human(count: :many).titleize.s %></a></h6>
+        <h6><a href="#collapseSeven" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= FeatureGeoCode.model_name.human(count: :many).titleize.s %></a></h6>
       </div>
-      <div id="collapseThirteen" class="panel-collapse collapse">
+      <div id="collapseSeven" class="panel-collapse collapse">
         <div class="panel-body">
-          <p><%=  ts 'accordion.etymology.help_text' %></p>
-<%=       highlighted_new_item_link [object, :etymology] %>
-          <br>
+          <p><%=  ts 'accordion.feature_geo_code.help_text' %></p>
+<%=       highlighted_new_item_link [object, :feature_geo_code] %>
           <br class="clear"/>
-<%=       render partial: 'admin/etymologies/list', locals: { list: object.etymologies } %>
+<%=       render partial: 'admin/feature_geo_codes/list', locals: { list: object.geo_codes } %>
+<%=       association_note_list_fieldset(FeatureGeoCode.name) %>
+        </div> <!-- END panel-body -->
+      </div> <!-- END collapseSeven -->
+    </section>
+    <section class="panel panel-default">
+      <div class="panel-heading">
+        <h6><a href="#collapsePassages" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Passage.model_name.human(count: :many).titleize.s %></a></h6>
+      </div>
+      <div id="collapsePassages" class="panel-collapse collapse">
+        <div class="panel-body">
+<%=       highlighted_new_item_link [object, :passage] %>
+          <br class="clear"/>
+<%=       render partial: 'admin/passages/list', locals: { list: object.passages.order('id DESC') } %>
         </div> <!-- END panel-body -->
       </div> <!-- END collapseTen -->
     </section>
+    <section class="panel panel-default">
+      <div class="panel-heading">
+        <h6><a href="#collapseFour" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Caption.model_name.human(count: :many).titleize.s %></a></h6>
+      </div>
+      <div id="collapseFour" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p><%=  ts 'accordion.caption.help_text' %></p>
+<%=       highlighted_new_item_link [object, :caption] %>
+          <br class="clear"/>
+<%=       render partial: 'admin/captions/list', locals: { list: object.captions } %>
+        </div> <!-- END panel-body -->
+      </div> <!-- END collapseFour -->
+    </section>
+    <section class="panel panel-default">
+      <div class="panel-heading">
+        <h6><a href="#collapseFive" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Summary.model_name.human(count: :many).titleize.s %></a></h6>
+      </div>
+      <div id="collapseFive" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p><%=  ts 'accordion.summary.help_text' %></p>
+<%=       highlighted_new_item_link [object, :summary] %>
+          <br class="clear"/>
+<%=       render partial: 'admin/summaries/list', locals: { list: object.summaries } %>
+        </div> <!-- END panel-body -->
+      </div> <!-- END collapseFive -->
+    </section>
+    <section class="panel panel-default">
+      <div class="panel-heading">
+        <h6><a href="#collapseNine" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Description.model_name.human(count: :many).titleize.s %></a></h6>
+      </div>
+      <div id="collapseNine" class="panel-collapse collapse">
+        <div class="panel-body">
+<%=       highlighted_new_item_link [object, :description] %>
+          <br class="clear"/>
+<%=       render partial: 'admin/descriptions/descriptions_list', locals: { list: object.descriptions.order('is_primary DESC, title') } %>
+<%=       association_note_list_fieldset(Description.name) %>
+        </div> <!-- END panel-body -->
+      </div> <!-- END collapseNine -->
+    </section>
+    <section class="panel panel-default">
+      <div class="panel-heading">
+        <h6><a href="#collapseSix" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Illustration.model_name.human(count: :many).titleize.s %></a></h6>
+      </div>
+      <div id="collapseSix" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p><%=  ts 'accordion.illustration.help_text', link: "<a href=\"https://confluence.its.virginia.edu/display/KB/Create+Images\">https://confluence.its.virginia.edu/display/KB/Create+Images</a>" %></p>
+<%=       highlighted_new_item_link [object, :illustration], "New #{Illustration.model_name.human.s}" %>
+          <br class="clear"/>
+<%=       render partial: 'admin/illustrations/list', locals: { list: object.illustrations } %>
+        </div> <!-- END panel-body -->
+      </div> <!-- END collapseSix -->
+    </section>
+
+    <section class="panel panel-default">
+      <div class="panel-heading">
+        <h6><a href="#collapseEleven" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Recording.model_name.human(count: :many).titleize.s %></a></h6>
+      </div>
+      <div id="collapseEleven" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p><%=  ts 'accordion.recording.help_text' %></p>
+<%=       highlighted_new_item_link [object, :recording] %>
+          <br class="clear"/>
+<%=       render partial: 'admin/recordings/list', locals: { list: object.recordings } %>
+        </div> <!-- END panel-body -->
+      </div> <!-- END collapseTen -->
+    </section>
+    
+    
   </div> <!-- END accordion -->
 </div> <!-- END featureShow -->

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -58,8 +58,8 @@ bo:
                 one: 'relation subject association'
                 other: 'relation subject associations'
             subject_term_association:
-                one: 'subject term association'
-                other: 'subject term associations'
+                one: 'term-subject association'
+                other: 'term-subject associations'
             view:
                 one: 'term script'
                 other: 'term scripts'

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -25,8 +25,8 @@ bo:
                 one: 'term'
                 other: 'terms'
             feature_geo_code:
-                one: 'term id'
-                other: 'term ids'
+                one: 'term legacy id'
+                other: 'term legacy ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -40,8 +40,8 @@ bo:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term code type'
-                other: 'term code types'
+                one: 'term legacy id type'
+                other: 'term legacy id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -42,6 +42,9 @@ bo:
             geo_code_type:
                 one: 'term code type'
                 other: 'term code types'
+            illustration:
+                one: 'homepage image'
+                other: 'homepage images'
             info_source:
                 one: 'dictionary'
                 other: 'dictionaries'

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -25,8 +25,8 @@ bo:
                 one: 'term'
                 other: 'terms'
             feature_geo_code:
-                one: 'term code'
-                other: 'term codes'
+                one: 'term id'
+                other: 'term ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -46,7 +46,7 @@ bo:
         etymology:
             help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
-            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -44,7 +44,7 @@ bo:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term.'
+            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -28,8 +28,8 @@ dz:
                 one: 'representation'
                 other: 'representations'
             feature_geo_code:
-                one: 'term code'
-                other: 'term codes'
+                one: 'term id'
+                other: 'term ids'
             feature_name_relation:
                 one: 'term name relation'
                 other: 'term name relations'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -40,8 +40,8 @@ dz:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term code type'
-                other: 'term code types'
+                one: 'term legacy id type'
+                other: 'term legacy id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -28,8 +28,8 @@ dz:
                 one: 'representation'
                 other: 'representations'
             feature_geo_code:
-                one: 'term id'
-                other: 'term ids'
+                one: 'term legacy id'
+                other: 'term legacy ids'
             feature_name_relation:
                 one: 'term name relation'
                 other: 'term name relations'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -42,6 +42,9 @@ dz:
             geo_code_type:
                 one: 'term code type'
                 other: 'term code types'
+            illustration:
+                one: 'homepage image'
+                other: 'homepage images'
             info_source:
                 one: 'dictionary'
                 other: 'dictionaries'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -58,8 +58,8 @@ dz:
                 one: 'relation subject association'
                 other: 'relation subject associations'
             subject_term_association:
-                one: 'subject term association'
-                other: 'subject term associations'
+                one: 'term-subject association'
+                other: 'term-subject associations'
             view:
                 one: 'term script'
                 other: 'term scripts'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -46,7 +46,7 @@ dz:
         etymology:
             help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
-            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -44,7 +44,7 @@ dz:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term.'
+            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -25,8 +25,8 @@ en:
                 one: 'term'
                 other: 'terms'
             feature_geo_code:
-                one: 'term id'
-                other: 'term ids'
+                one: 'term legacy id'
+                other: 'term legacy ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -42,6 +42,9 @@ en:
             geo_code_type:
                 one: 'term code type'
                 other: 'term code types'
+            illustration:
+                one: 'homepage image'
+                other: 'homepage images'
             info_source:
                 one: 'dictionary'
                 other: 'dictionaries'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -61,8 +61,8 @@ en:
                 one: 'relation subject association'
                 other: 'relation subject associations'
             subject_term_association:
-                one: 'subject term association'
-                other: 'subject term associations'
+                one: 'term-subject association'
+                other: 'term-subject associations'
             view:
                 one: 'term script'
                 other: 'term scripts'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -25,8 +25,8 @@ en:
                 one: 'term'
                 other: 'terms'
             feature_geo_code:
-                one: 'term code'
-                other: 'term codes'
+                one: 'term id'
+                other: 'term ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -40,8 +40,8 @@ en:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term code type'
-                other: 'term code types'
+                one: 'term legacy id type'
+                other: 'term legacy id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -44,7 +44,7 @@ en:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term.'
+            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -46,7 +46,7 @@ en:
         etymology:
             help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
-            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -28,8 +28,8 @@ zh:
                 one: 'representation'
                 other: 'representations'
             feature_geo_code:
-                one: 'term code'
-                other: 'term codes'
+                one: 'term id'
+                other: 'term ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -28,8 +28,8 @@ zh:
                 one: 'representation'
                 other: 'representations'
             feature_geo_code:
-                one: 'term id'
-                other: 'term ids'
+                one: 'term legacy id'
+                other: 'term legacy ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -45,6 +45,9 @@ zh:
             geo_code_type:
                 one: 'term code type'
                 other: 'term code types'
+            illustration:
+                one: 'homepage image'
+                other: 'homepage images'
             info_source:
                 one: 'dictionary'
                 other: 'dictionaries'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -43,8 +43,8 @@ zh:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term code type'
-                other: 'term code types'
+                one: 'term legacy id type'
+                other: 'term legacy id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -61,8 +61,8 @@ zh:
                 one: 'relation subject association'
                 other: 'relation subject associations'
             subject_term_association:
-                one: 'subject term association'
-                other: 'subject term associations'
+                one: 'term-subject association'
+                other: 'term-subject associations'
             view:
                 one: 'term script'
                 other: 'term scripts'

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -46,7 +46,7 @@ zh:
         etymology:
             help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
-            help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:
             accordion_title: 'Transcriptions and Transliterations'
         illustration:

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -44,7 +44,7 @@ zh:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term.'
+            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
         feature_geo_code:
             help_text: 'Term codes are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         feature_name:


### PR DESCRIPTION
**MANU-7794 MANU-7820 MANU-7821 MANU-7838 MANU-7839** 


https://uvaissues.atlassian.net/browse/MANU-7794
 + Change 'illustrations' to 'homepage images'. Adds translation to config/locales/[lang]/models and uses that key in all views. Changes also occur in kmaps_engine views for Illustrations.

https://uvaissues.atlassian.net/browse/MANU-7820
 + Change "Term Codes" to "Term Ids". Adds translation to config/locales/[lang]/models. No updates to views.

https://uvaissues.atlassian.net/browse/MANU-7821
 + Adds clarifying text to Etymologies help text.

https://uvaissues.atlassian.net/browse/MANU-7838
 + Reorder the items in the accordion

https://uvaissues.atlassian.net/browse/MANU-7839
 + Rename subject term associations to "term-subject associations"

Changes requested via https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit#heading=h.uq3d5egrwqp5
