### PR TITLE
MANU-7887 breadcrumbs to use translations

### DIFF
--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(parent_object)
-   add_breadcrumb_item link_to 'definitions', admin_feature_definitions_path(parent_object)
+   add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, admin_feature_definitions_path(parent_object)
    add_breadcrumb_item object.id %>
  <section class="panel panel-content">
    <div class="panel-heading">

--- a/app/views/admin/recordings/edit.html.erb
+++ b/app/views/admin/recordings/edit.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'recordings', admin_feature_recordings_path(object.feature)
+   add_breadcrumb_item link_to Recording.model_name.human(count: :many).titleize.s, admin_feature_recordings_path(object.feature)
    add_breadcrumb_item object.id %>
 <section class="panel panel-content">
   <div class="panel-heading">

--- a/app/views/admin/recordings/new.html.erb
+++ b/app/views/admin/recordings/new.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'recordings', admin_feature_recordings_path(object.feature)
+   add_breadcrumb_item link_to Recording.model_name.human(count: :many).titleize.s, admin_feature_recordings_path(object.feature)
 %>
 <div>
   <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: Recording.model_name.human.titleize)), whom: "#{Feature.model_name.human.titleize} #{parent_object}" %></h1>

--- a/app/views/admin/recordings/show.html.erb
+++ b/app/views/admin/recordings/show.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'recordings', admin_feature_recordings_path(object.feature)
+   add_breadcrumb_item link_to Recording.model_name.human(count: :many).titleize.s, admin_feature_recordings_path(object.feature)
 %>
 <section class="panel panel-content">
   <div class="panel-heading">

--- a/app/views/admin/subject_term_associations/edit.html.erb
+++ b/app/views/admin/subject_term_associations/edit.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'subject term association', admin_feature_subject_term_associations_path(object.feature)
+   add_breadcrumb_item link_to ts(SubjectTermAssociation.model_name.human(count: :many).titleize.s), admin_feature_subject_term_associations_path(object.feature)
    add_breadcrumb_item object.id %>
 <section class="panel panel-content">
   <div class="panel-heading">

--- a/app/views/admin/subject_term_associations/edit.html.erb
+++ b/app/views/admin/subject_term_associations/edit.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to ts(SubjectTermAssociation.model_name.human(count: :many).titleize.s), admin_feature_subject_term_associations_path(object.feature)
+   add_breadcrumb_item link_to SubjectTermAssociation.model_name.human(count: :many).titleize.s, admin_feature_subject_term_associations_path(object.feature)
    add_breadcrumb_item object.id %>
 <section class="panel panel-content">
   <div class="panel-heading">

--- a/app/views/admin/subject_term_associations/new.html.erb
+++ b/app/views/admin/subject_term_associations/new.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to ts(SubjectTermAssociation.model_name.human(count: :many).titleize.s), admin_feature_subject_term_associations_path(object.feature)
+   add_breadcrumb_item link_to SubjectTermAssociation.model_name.human(count: :many).titleize.s, admin_feature_subject_term_associations_path(object.feature)
 %>
 <div>
   <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: SubjectTermAssociation.model_name.human.titleize)), whom: "#{Feature.model_name.human.titleize} #{parent_object}" %></h1>

--- a/app/views/admin/subject_term_associations/new.html.erb
+++ b/app/views/admin/subject_term_associations/new.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'subject term association', admin_feature_subject_term_associations_path(object.feature)
+   add_breadcrumb_item link_to ts(SubjectTermAssociation.model_name.human(count: :many).titleize.s), admin_feature_subject_term_associations_path(object.feature)
 %>
 <div>
   <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: SubjectTermAssociation.model_name.human.titleize)), whom: "#{Feature.model_name.human.titleize} #{parent_object}" %></h1>

--- a/app/views/admin/subject_term_associations/show.html.erb
+++ b/app/views/admin/subject_term_associations/show.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to ts(SubjectTermAssociation.model_name.human(count: :many).titleize.s), admin_feature_subject_term_associations_path
+   add_breadcrumb_item link_to SubjectTermAssociation.model_name.human(count: :many).titleize.s, admin_feature_subject_term_associations_path
    add_breadcrumb_item object.id %>
  <section class="panel panel-content">
    <div class="panel-heading">

--- a/app/views/admin/subject_term_associations/show.html.erb
+++ b/app/views/admin/subject_term_associations/show.html.erb
@@ -21,7 +21,7 @@
      <% if !defined?(parent_object) %>
        <%= link_to ts('back.this'), admin_path  %>
      <% else %>
-       <%=  link_to ts('cancel.this'), admin_feature_path(object.feature), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+       <%=  link_to ts('cancel.this'), admin_feature_path(object.feature, section: "subjectAssociations"), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>
   </div> <!-- END panel-body -->
  </section> <!-- END panel -->

--- a/app/views/admin/subject_term_associations/show.html.erb
+++ b/app/views/admin/subject_term_associations/show.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'subject term associations', admin_feature_subject_term_associations_path
+   add_breadcrumb_item link_to ts(SubjectTermAssociation.model_name.human(count: :many).titleize.s), admin_feature_subject_term_associations_path
    add_breadcrumb_item object.id %>
  <section class="panel panel-content">
    <div class="panel-heading">


### PR DESCRIPTION
**https://uvaissues.atlassian.net/browse/MANU-7887** 

* some views were using hardcoded strings for breadcrumb link output instead of using the model_name set in the translation files. This corrects that. This also requires changes made in kmaps_engine, pull request here:  https://github.com/shanti-uva/kmaps_engine/pull/57