### PR TITLE
Feedback fixes. 7777 7720 7821 7849 7851 588 7840

### DIFF
--- a/app/assets/javascripts/terms_engine/definition_subject_associations_admin.js
+++ b/app/assets/javascripts/terms_engine/definition_subject_associations_admin.js
@@ -127,4 +127,6 @@ $(document).ready(function() {
     $("#subject_tree_container").toggle();
   });
 
+  // just show this by default now
+  $("#branch_tree_container").toggle();
 });

--- a/app/assets/stylesheets/terms_engine/definition_subject_associations.css
+++ b/app/assets/stylesheets/terms_engine/definition_subject_associations.css
@@ -1,9 +1,16 @@
 .definition-subject-associations-form-fields input#branch_name, input#subject_name {
-    padding-left: 0;
+  padding-left: 0;
 }
 .definition-subject-associations-form-fields .row, .twitter-typeahead {
- margin: 0 0 0.2rem 1rem;
+  margin: 0 0 0.2rem 1rem;
+  display: inline !important;
+}
+.definition-subject-associations-form-fields .row, .twitter-typeahead {
+  margin: 0 0 0.2rem 1rem;
 }
 .definition-subject-associations-form-fields .row {
   padding-top: 10px;
+}
+.definition-subject-associations-form-fields p {
+  margin: 0.8rem;
 }

--- a/app/helpers/admin/definition_subject_associations_helper.rb
+++ b/app/helpers/admin/definition_subject_associations_helper.rb
@@ -1,7 +1,7 @@
 module Admin::DefinitionSubjectAssociationsHelper
   def new_definition_subject_associations_links(definition)
     DefinitionSubjectAssociation.select('branch_id').distinct.sort_by {|a| a.branch['header']}.collect do |a|
-      link_to "#{a.branch['header']} association", new_admin_definition_definition_subject_association_path(definition, branch_id: a.branch_id)
-    end.join(" | ").html_safe
+      "<li>#{link_to a.branch['header'], new_admin_definition_definition_subject_association_path(definition, branch_id: a.branch_id)}</li>"
+    end.join("").html_safe
   end
 end

--- a/app/views/admin/definition_subject_associations/_form_fields.html.erb
+++ b/app/views/admin/definition_subject_associations/_form_fields.html.erb
@@ -23,7 +23,7 @@
     </div>
 	
     <div class="sidePanel" id="subject_container">
-      <%= form.label :subject_name, DefinitionSubjectAssociation.human_attribute_name('subsidiary').s %>
+      <%= form.label :subject_name, DefinitionSubjectAssociation.human_attribute_name('subject').s %>
       <%= info_popup_link_for('Subject', "<p>The <i>subsidiary subject</i> refers to the specific instance such as <i>The Vehicle of the Yoga Tantras</i> under the general category specified above as <i>root subject</i>.</p>", 100) %>
       <%= form.hidden_field :subject_id, id: :subject_id %>
       <%= text_field_tag :subject_name, :post, { placeholder: 'Search by subject name', value: object.subject.blank? ? '' : object.subject['header'] } %>

--- a/app/views/admin/definition_subject_associations/_form_fields.html.erb
+++ b/app/views/admin/definition_subject_associations/_form_fields.html.erb
@@ -12,28 +12,24 @@
 <% end %>
 <fieldset>
   <legend><%= ts(:for, what: t('information.general'), whom: DefinitionSubjectAssociation.model_name.human.titleize) %></legend>
-  <div class="row">
-    <%= form.label :branch_name, DefinitionSubjectAssociation.human_attribute_name('branch').s %>
-    <%= info_popup_link_for('Branch', "<p>The <i>branch</i> refers to the general category such as <i>Religious Systems</i> from which a specific instance under it will be chosen as <i>subject</i> below.</p>", 100) %>
-    <%= form.hidden_field :branch_id, id: :branch_id %>
-    <br/>
-    <br/>
-    <p>Search by name</p>
-    <%= text_field_tag :branch_name, :post, { placeholder: 'Search by branch name', value: object.branch.blank? ? '' : object.branch['header'] } %>
-    <a href="#" id="js-expand-branch-tree">Or click here to view branch hierarchy</a>
-     <div id="branch_tree_container"></div>
-  </div>
-	<br/>
-  <div class="row" id="subject_container">
-    <%= form.label :subject_name, SubjectsIntegration::Feature.human_name(count: 1).titleize %>
-    <%= info_popup_link_for('Subject', "<p>The <i>subject</i> refers to the specific instance such as <i>The Vehicle of the Yoga Tantras</i> under the general category specified above as <i>branch</i>.</p>", 100) %>
-    <%= form.hidden_field :subject_id, id: :subject_id %>
-    <br/>
-    <br/>
-    <p>Search by name</p>
-    <%= text_field_tag :subject_name, :post, { placeholder: 'Search by subject name', value: object.subject.blank? ? '' : object.subject['header'] } %>
-    <a href="#" id="js-expand-subject-tree">Or click here to view subject hierarchy</a>
+  <div class="flexContainer">
+    <div class="sidePanel">
+      <%= form.label :branch_name, DefinitionSubjectAssociation.human_attribute_name('branch').s %>
+      <%= info_popup_link_for('Branch', "<p>The <i>root subject</i> refers to the general category such as <i>Religious Systems</i> from which a specific instance under it will be chosen as <i>subsidiary subject</i> below.</p>", 100) %>
+      <%= form.hidden_field :branch_id, id: :branch_id %>
+      <%= text_field_tag :branch_name, :post, { placeholder: 'Search by branch name', value: object.branch.blank? ? '' : object.branch['header'] } %>
+      <p>If you want to view a different root subject, replace the text in the box above and search for it. Or, use the tree below to select the root subject.</p>
+       <div id="branch_tree_container"></div>
+    </div>
+	
+    <div class="sidePanel" id="subject_container">
+      <%= form.label :subject_name, DefinitionSubjectAssociation.human_attribute_name('subsidiary').s %>
+      <%= info_popup_link_for('Subject', "<p>The <i>subsidiary subject</i> refers to the specific instance such as <i>The Vehicle of the Yoga Tantras</i> under the general category specified above as <i>root subject</i>.</p>", 100) %>
+      <%= form.hidden_field :subject_id, id: :subject_id %>
+      <%= text_field_tag :subject_name, :post, { placeholder: 'Search by subject name', value: object.subject.blank? ? '' : object.subject['header'] } %>
+     <p>If you want to search for a specific subject node within the above ROOT SUBJECT and its descendants,  put the text in the box above and search for it.</p>
      <div id="subject_tree_container"></div>
+    </div>
   </div>
 </fieldset>
 </div> <!-- END - subject-term-associations-form-fields -->

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -124,7 +124,7 @@
          </div>
          <div id="collapseFour" class="panel-collapse collapse">
            <div class="panel-body">
-<%=          highlighted_new_item_link [object, :definition_subject_association] %>
+<%=          highlighted_new_item_link [object, :definition_subject_association], ts('new.record', what: DefinitionSubjectAssociation.model_name.human.titleize) %>
              <br>
              <h6>Create Specific Association:</h6>
              <ul>

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -127,7 +127,9 @@
 <%=          highlighted_new_item_link [object, :definition_subject_association] %>
              <br>
              <h6>Create Specific Association:</h6>
+             <ul>
 <%=          new_definition_subject_associations_links object %>
+             </ul>
              <br class="clear"/>
 <%=          render partial: 'admin/definition_subject_associations/list', locals: { list: object.definition_subject_associations } %>
            </div> <!-- END panel-body -->

--- a/app/views/admin/subject_term_associations/_form_fields.html.erb
+++ b/app/views/admin/subject_term_associations/_form_fields.html.erb
@@ -22,7 +22,7 @@
       <div id="branch_tree_container"></div>
     </div>
     <div class="sidePanel" id="subject_container">
-      <%= form.label :subject_name, SubjectTermAssociation.human_attribute_name('subsidiary').s %> 
+      <%= form.label :subject_name, SubjectTermAssociation.human_attribute_name('subject').s %> 
       <%= form.hidden_field :subject_id, id: :subject_id %>
     
       <%= text_field_tag :subject_name, :post, { placeholder: "Search by #{SubjectTermAssociation.human_attribute_name('subsidiary').s} name", value: object.subject.blank? ? '' : object.subject['header'] } %>

--- a/app/views/admin/subject_term_associations/_form_fields.html.erb
+++ b/app/views/admin/subject_term_associations/_form_fields.html.erb
@@ -12,21 +12,23 @@
 <% end %>
 <fieldset>
   <legend><%= ts(:for, what: t('information.general'), whom: SubjectTermAssociation.model_name.human.titleize) %></legend>
-  <div class="row">
-    <%= form.label :branch_name, SubjectTermAssociation.human_attribute_name('branch').s %>
-    <%= form.hidden_field :branch_id, id: :branch_id %>
-    Search by name 
-    <%= text_field_tag :branch_name, :post, { placeholder: "Search by #{SubjectTermAssociation.model_name.human} name", value: object.branch.blank? ? '' : object.branch['header'] } %><br/>
-    <p>If you want to view a different root subject, replace the text in the box above and search for it. Or, use the tree below to select the root subject.</p>
-     <div id="branch_tree_container"></div>
-  </div>
-  <div class="row" id="subject_container">
-    <%= form.label :subject_name, SubjectTermAssociation.human_attribute_name('subsidiary').s %> 
-    <%= form.hidden_field :subject_id, id: :subject_id %>
-    Search by name 
-    <%= text_field_tag :subject_name, :post, { placeholder: "Search by #{SubjectTermAssociation.human_attribute_name('subsidiary').s} name", value: object.subject.blank? ? '' : object.subject['header'] } %>
-    <p>If you want to search for a specific subject node within the above ROOT SUBJECT and its descendants,  put the text in the box above and search for it.</p>
-     <div id="subject_tree_container"></div>
+  <div class="flexContainer">
+    <div class="sidePanel">
+      <%= form.label :branch_name, SubjectTermAssociation.human_attribute_name('branch').s %>
+      <%= form.hidden_field :branch_id, id: :branch_id %>
+    
+      <%= text_field_tag :branch_name, :post, { placeholder: "Search by #{SubjectTermAssociation.model_name.human} name", value: object.branch.blank? ? '' : object.branch['header'] } %><br/>
+      <p>If you want to view a different root subject, replace the text in the box above and search for it. Or, use the tree below to select the root subject.</p>
+      <div id="branch_tree_container"></div>
+    </div>
+    <div class="sidePanel" id="subject_container">
+      <%= form.label :subject_name, SubjectTermAssociation.human_attribute_name('subsidiary').s %> 
+      <%= form.hidden_field :subject_id, id: :subject_id %>
+    
+      <%= text_field_tag :subject_name, :post, { placeholder: "Search by #{SubjectTermAssociation.human_attribute_name('subsidiary').s} name", value: object.subject.blank? ? '' : object.subject['header'] } %>
+      <p>If you want to search for a specific subject node within the above ROOT SUBJECT and its descendants,  put the text in the box above and search for it.</p>
+      <div id="subject_tree_container"></div>
+    </div>
   </div>
 </fieldset>
 </div> <!-- END - subject-term-associations-form-fields -->

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -31,8 +31,8 @@ bo:
                 one: 'representation'
                 other: 'representations'
             feature_name_relation:
-                one: 'term name relation'
-                other: 'term name relations'
+                one: 'term representation relation'
+                other: 'term representation relations'
             feature_relation:
                 one: 'term relation'
                 other: 'term relations'

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -10,8 +10,8 @@ bo:
                 one: 'definition relation'
                 other: 'definition relations'
             definition_subject_association:
-                one: 'definition subject association'
-                other: 'definition subject associations'
+                one: 'definition related subject'
+                other: 'definition related subjects'
             etymology:
                 one: 'etymology'
                 other: 'etymologies'
@@ -67,8 +67,11 @@ bo:
         attributes:
             definition_subject_association:
                 branch:
-                    one: 'Branch'
-                    other: 'Branches'
+                    one: 'root subject'
+                    other: 'root subjects'
+                subsidiary:
+                    one: 'subsidiary subject'
+                    other: 'subsidiary subjects'
             etymology:
                 content: 'Content'
                 etymology_type_association:

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -25,8 +25,8 @@ bo:
                 one: 'term'
                 other: 'terms'
             feature_geo_code:
-                one: 'term legacy id'
-                other: 'term legacy ids'
+                one: 'other dictionary id'
+                other: 'other dictionary ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'
@@ -40,8 +40,8 @@ bo:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term legacy id type'
-                other: 'term legacy id types'
+                one: 'other dictionary id type'
+                other: 'other dictionary id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -69,7 +69,7 @@ bo:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'
             etymology:
@@ -101,6 +101,6 @@ bo:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -44,7 +44,7 @@ bo:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
+            help_text: 'This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question. An etymology can just be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology.'
         feature_geo_code:
             help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         illustration:

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -69,7 +69,7 @@ dz:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'
             etymology:
@@ -101,6 +101,6 @@ dz:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -10,8 +10,8 @@ dz:
                 one: 'definition relation'
                 other: 'definition relations'
             definition_subject_association:
-                one: 'definition subject association'
-                other: 'definition subject associations'
+                one: 'definition related subject'
+                other: 'definition related subjects'
             etymology:
                 one: 'etymology'
                 other: 'etymologies'
@@ -67,8 +67,11 @@ dz:
         attributes:
             definition_subject_association:
                 branch:
-                    one: 'Branch'
-                    other: 'Branches'
+                    one: 'root subject'
+                    other: 'root subjects'
+                subsidiary:
+                    one: 'subsidiary subject'
+                    other: 'subsidiary subjects'
             etymology:
                 content: 'Content'
                 etymology_type_association:

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -28,8 +28,8 @@ dz:
                 one: 'representation'
                 other: 'representations'
             feature_geo_code:
-                one: 'term legacy id'
-                other: 'term legacy ids'
+                one: 'other dictionary id'
+                other: 'other dictionary ids'
             feature_name_relation:
                 one: 'term representation relation'
                 other: 'term representation relations'
@@ -40,8 +40,8 @@ dz:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term legacy id type'
-                other: 'term legacy id types'
+                one: 'other dictionary id type'
+                other: 'other dictionary id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -31,8 +31,8 @@ dz:
                 one: 'term legacy id'
                 other: 'term legacy ids'
             feature_name_relation:
-                one: 'term name relation'
-                other: 'term name relations'
+                one: 'term representation relation'
+                other: 'term representation relations'
             feature_relation:
                 one: 'term relation'
                 other: 'term relations'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -44,7 +44,7 @@ dz:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
+            help_text: 'This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question. An etymology can just be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology.'
         feature_geo_code:
             help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         illustration:

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -10,8 +10,8 @@ en:
                 one: 'definition relation'
                 other: 'definition relations'
             definition_subject_association:
-                one: 'definition subject association'
-                other: 'definition subject associations'
+                one: 'definition related subject'
+                other: 'definition related subjects'
             etymology:
                 one: 'etymology'
                 other: 'etymologies'
@@ -70,8 +70,11 @@ en:
         attributes:
             definition_subject_association:
                 branch:
-                    one: 'Branch'
-                    other: 'Branches'
+                    one: 'root subject'
+                    other: 'root subjects'
+                subsidiary:
+                    one: 'subsidiary subject'
+                    other: 'subsidiary subjects'
             etymology:
                 content: 'Content'
                 etymology_type_association:

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -72,7 +72,7 @@ en:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'
             etymology:
@@ -104,6 +104,6 @@ en:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -31,8 +31,8 @@ en:
                 one: 'representation'
                 other: 'representations'
             feature_name_relation:
-                one: 'term name relation'
-                other: 'term name relations'
+                one: 'term representation relation'
+                other: 'term representation relations'
             feature_relation:
                 one: 'term relation'
                 other: 'term relations'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -25,8 +25,8 @@ en:
                 one: 'term'
                 other: 'terms'
             feature_geo_code:
-                one: 'term legacy id'
-                other: 'term legacy ids'
+                one: 'other dictionary id'
+                other: 'other dictionary ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'
@@ -40,8 +40,8 @@ en:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term legacy id type'
-                other: 'term legacy id types'
+                one: 'other dictionary id type'
+                other: 'other dictionary id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -44,7 +44,7 @@ en:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
+            help_text: 'This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question. An etymology can just be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology.'
         feature_geo_code:
             help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         illustration:

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -28,8 +28,8 @@ zh:
                 one: 'representation'
                 other: 'representations'
             feature_geo_code:
-                one: 'term legacy id'
-                other: 'term legacy ids'
+                one: 'other dictionary id'
+                other: 'other dictionary ids'
             feature_name:
                 one: 'representation'
                 other: 'representations'
@@ -43,8 +43,8 @@ zh:
                 one: 'term relation type'
                 other: 'term relation types'
             geo_code_type:
-                one: 'term legacy id type'
-                other: 'term legacy id types'
+                one: 'other dictionary id type'
+                other: 'other dictionary id types'
             illustration:
                 one: 'homepage image'
                 other: 'homepage images'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -10,8 +10,8 @@ zh:
                 one: 'definition relation'
                 other: 'definition relations'
             definition_subject_association:
-                one: 'definition subject association'
-                other: 'definition subject associations'
+                one: 'definition related subject'
+                other: 'definition related subjects'
             etymology:
                 one: 'etymology'
                 other: 'etymologies'
@@ -70,8 +70,11 @@ zh:
         attributes:
             definition_subject_association:
                 branch:
-                    one: 'Branch'
-                    other: 'Branches'
+                    one: 'root subject'
+                    other: 'root subjects'
+                subsidiary:
+                    one: 'subsidiary subject'
+                    other: 'subsidiary subjects'
             etymology:
                 content: 'Content'
                 etymology_type_association:

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -34,8 +34,8 @@ zh:
                 one: 'representation'
                 other: 'representations'
             feature_name_relation:
-                one: 'term name relation'
-                other: 'term name relations'
+                one: 'term representation relation'
+                other: 'term representation relations'
             feature_relation:
                 one: 'term relation'
                 other: 'term relations'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -72,7 +72,7 @@ zh:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'
             etymology:
@@ -104,6 +104,6 @@ zh:
                 branch:
                     one: 'root subject'
                     other: 'root subjects'
-                subsidiary:
+                subject:
                     one: 'subsidiary subject'
                     other: 'subsidiary subjects'

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -44,7 +44,7 @@ zh:
         caption:
             help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
         etymology:
-            help_text: 'The origin of the term. This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question.'
+            help_text: 'This is for etymologies pertaining to the entire term. If one wants to add a definition-specific etymology, go the Definitions  module and there click on the magnifying glass on the definition in question. An etymology can just be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology.'
         feature_geo_code:
             help_text: 'Term legacy ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
         illustration:


### PR DESCRIPTION
https://uvaissues.atlassian.net/browse/MANU-7777
* change name to representation

https://uvaissues.atlassian.net/browse/MANU-7720
* change term legacy id to other dictionary id

https://uvaissues.atlassian.net/browse/MANU-7821
* revise etymology help text per feedback

https://uvaissues.atlassian.net/browse/MANU-7849
https://uvaissues.atlassian.net/browse/MANU-7851
https://uvaissues.atlassian.net/browse/MANU-7885
https://uvaissues.atlassian.net/browse/MANU-7840
* put root subject and subsidiary subject sections side by side instead of one following the other
* implement changes from SUBJECT TERM ASSOCIATIONS under DEFINITION SUBJECT ASSOCIATIONS
* call it RELATED SUBJECTS and DEFINITION RELATED SUBJECTS instead

