### PR TITLE
MANU-7873 MANU-7891 MANU-7917 MANU-7786

### DIFF
--- a/app/assets/javascripts/terms_engine/definitions_admin_accordion.js
+++ b/app/assets/javascripts/terms_engine/definitions_admin_accordion.js
@@ -19,6 +19,9 @@ $(document).ready(function() {
         case('passages'):
           handleFeatureAccordion('collapsePassages');
           break;
+        case('passage_translations'):
+          handleFeatureAccordion('collapsePassageTranslations');
+          break;
         case('related_subjects'):
           handleFeatureAccordion('collapseFour');
           break;

--- a/app/assets/javascripts/terms_engine/passages_admin_accordion.js
+++ b/app/assets/javascripts/terms_engine/passages_admin_accordion.js
@@ -1,0 +1,31 @@
+$(document).ready(function() {
+
+    if( $('.logged-in.page-terms #passageShow #accordion').length ) { // only run this on the admin passage accordion in terms_engine
+
+      const section = window.location.href.split('=')[1];
+      if( section == null || section === undefined ) { return; } // exit if we didn't get a section
+
+      switch(section) {
+        // TODO add notes section
+        case('citations'):
+          handleFeatureAccordion('collapseCitations');
+          break;
+        case('passage_translations'):
+          handleFeatureAccordion('collapsePassageTranslations');
+          break;
+        default:
+          //handleFeatureAccordion('collapseOne');
+          break;
+      }
+      
+      function handleFeatureAccordion(el){
+        // General Information is shown by default so hide it
+        $('#collapseOne').collapse('hide');
+        $('#' + el).collapse('toggle');
+        setTimeout(1000);
+        //TODO there is something else running on the page that prevents this from working consistently.
+        //It has to do with the sidebar list of terms.
+        document.getElementById(el).scrollIntoView({behavior: "smooth" });
+      }
+    }
+});

--- a/app/controllers/admin/etymology_subject_associations_controller.rb
+++ b/app/controllers/admin/etymology_subject_associations_controller.rb
@@ -6,7 +6,9 @@ class Admin::EtymologySubjectAssociationsController < AclController
 
   new_action.before { object.branch_id = params[:branch_id] if params[:branch_id] }
 
-  destroy.wants.html { redirect_to polymorphic_url([:admin,object.etymology]) }
+  create.wants.html  { redirect_to polymorphic_url(helpers.stacked_parents) }
+  update.wants.html  { redirect_to polymorphic_url(helpers.stacked_parents) }
+  destroy.wants.html { redirect_to polymorphic_url(helpers.stacked_parents) }
 
   protected
 

--- a/app/controllers/admin/passage_translations_controller.rb
+++ b/app/controllers/admin/passage_translations_controller.rb
@@ -4,6 +4,14 @@ class Admin::PassageTranslationsController < AclController
 
   belongs_to :definition, :passage
 
+  new_action.before do
+    @languages = Language.order('name')
+  end
+
+  edit.before do
+    @languages = Language.order('name')
+  end
+
   protected
 
   # Only allow a trusted parameter "white list" through.

--- a/app/controllers/admin/passage_translations_controller.rb
+++ b/app/controllers/admin/passage_translations_controller.rb
@@ -20,7 +20,7 @@ class Admin::PassageTranslationsController < AclController
 
   # Only allow a trusted parameter "white list" through.
   def passage_translation_params
-    params.require(:passage_translation).permit(:context_id, :context_type, :content, :language)
+    params.require(:passage_translation).permit(:context_id, :context_type, :content, :language_id)
   end
   
 end

--- a/app/controllers/admin/passage_translations_controller.rb
+++ b/app/controllers/admin/passage_translations_controller.rb
@@ -1,0 +1,15 @@
+class Admin::PassageTranslationsController < AclController
+  include KmapsEngine::ResourceObjectAuthentication
+  resource_controller
+
+  belongs_to :definition, :passage
+
+  protected
+
+  # Only allow a trusted parameter "white list" through.
+  def passage_translation_params
+    params.require(:passage_translation).permit(:context_id, :context_type, :content)
+  end
+  
+end
+

--- a/app/controllers/admin/passage_translations_controller.rb
+++ b/app/controllers/admin/passage_translations_controller.rb
@@ -12,11 +12,15 @@ class Admin::PassageTranslationsController < AclController
     @languages = Language.order('name')
   end
 
+  create.before do
+    @languages = Language.order('name')
+  end
+
   protected
 
   # Only allow a trusted parameter "white list" through.
   def passage_translation_params
-    params.require(:passage_translation).permit(:context_id, :context_type, :content)
+    params.require(:passage_translation).permit(:context_id, :context_type, :content, :language)
   end
   
 end

--- a/app/controllers/admin/passage_translations_controller.rb
+++ b/app/controllers/admin/passage_translations_controller.rb
@@ -16,6 +16,28 @@ class Admin::PassageTranslationsController < AclController
     @languages = Language.order('name')
   end
 
+  create.wants.html do
+    if object.context.instance_of? Definition
+      redirect_to polymorphic_url( [:admin, object.context.feature, object.context], section: 'passage_translations' )
+    else
+      redirect_to polymorphic_url( [:admin, object.context], section: 'passage_translations' )
+    end
+  end
+  update.wants.html do
+    if object.context.instance_of? Definition
+      redirect_to polymorphic_url( [:admin, object.context.feature, object.context], section: 'passage_translations' )
+    else
+      redirect_to polymorphic_url( [:admin, object.context], section: 'passage_translations' )
+    end
+  end
+  destroy.wants.html do
+    if object.context.instance_of? Definition
+      redirect_to polymorphic_url( [:admin, object.context.feature, object.context], section: 'passage_translations' )
+    else
+      redirect_to polymorphic_url( [:admin, object.context], section: 'passage_translations' )
+    end
+  end
+
   protected
 
   # Only allow a trusted parameter "white list" through.

--- a/app/views/admin/definitions/_list_in_house.html.erb
+++ b/app/views/admin/definitions/_list_in_house.html.erb
@@ -1,0 +1,23 @@
+   <table class="listGrid">
+<%   list.each do |row|
+       source = InfoSource.find(row.first)
+       definitions = row.last
+       size = definitions.size
+       definitions.each do |item| %>
+       <tr>
+<%       if !source.nil? %>
+           <td rowspan="<%= size %>"><%= source.title %></td>
+<%         source = nil
+         end %>
+         <td class="centerText">
+<%=        list_actions_for_item(item, delete_path: admin_feature_definition_path(item.feature, item),
+           edit_path: edit_admin_feature_definition_path(item.feature, item),
+           view_path: admin_feature_definition_path(item.feature, item), 
+           hide_edit: true) %>
+         </td>
+         <td><%= item.language.name %></td>
+         <td><%= item.snippet.s %></td>
+     </tr>
+<%     end
+     end %>
+   </table>

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -13,7 +13,7 @@
      <div>
        <h1><%= Definition.model_name.human.titleize.s %>:</h1>
        <p>
-<%=      @definition.content.s %>
+<%=      object.content.s %>
        </p>
      </div>
      <br class="clear"/>
@@ -29,19 +29,19 @@
                  <label><%= FeatureName.model_name.human.titleize.s %>:</label> <span><%= parent_object.name %></span>
                </div>
                <div class="row">
-                 <label><%= Definition.human_attribute_name(:is_public).s %>:</label> <span><%= @definition.is_public %></span>
+                 <label><%= Definition.human_attribute_name(:is_public).s %>:</label> <span><%= object.is_public %></span>
                </div>
                <div class="row">
-                 <label><%= Definition.human_attribute_name(:is_primary).s %>:</label> <span><%= @definition.is_primary %></span>
+                 <label><%= Definition.human_attribute_name(:is_primary).s %>:</label> <span><%= object.is_primary %></span>
                </div>
                <div class="row">
                  <label><%= Definition.human_attribute_name(:author)%>:</label> <span><%= def_if_blank object, :author, :fullname %></span>
                </div>
                <div class="row">
-                 <label><%= Definition.human_attribute_name(:numerology)%>:</label> <span><%= @definition.numerology%></span>
+                 <label><%= Definition.human_attribute_name(:numerology)%>:</label> <span><%= object.numerology%></span>
                </div>
                <div class="row">
-                 <label><%= Definition.human_attribute_name(:tense)%>:</label> <span><%= @definition.tense%></span>
+                 <label><%= Definition.human_attribute_name(:tense)%>:</label> <span><%= object.tense%></span>
                </div>
                <div class="row">
                  <label><%= ts 'creat.e.d' %>:</label> <span><%= object.created_at.to_formatted_s(:us_datetime) %></span>

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -1,7 +1,8 @@
 <% 
   add_breadcrumb_item feature_link(object.feature)
   add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, admin_feature_path(object.feature.fid, section: 'definitions')
-  add_breadcrumb_item @definition.content.strip_tags.truncate(25).s 
+
+  add_breadcrumb_item object.content.strip_tags.blank? ? object.id : object.content.strip_tags.truncate(25).s 
 %>
 <div id="definitionShow" style="position:relative;">
  <section class="panel panel-content ">
@@ -128,6 +129,7 @@
            <div id="collapsePassageTranslations" class="panel-collapse collapse">
              <div class="panel-body">
                <%=       highlighted_new_item_link [object, :passage_translation] %>
+               <br class="clear" />
                <%= render :partial => 'admin/passage_translations/list', :locals => { :list => object.passage_translations } %>
            </div> <!-- END panel-body -->
          </div> <!-- END collapseTwo -->

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -122,6 +122,17 @@
          </div> <!-- END collapseTen -->
        </section>
        <section class="panel panel-default">
+           <div class="panel-heading">
+             <h6><a href="#collapsePassageTranslations" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= PassageTranslation.model_name.human(count: :many).titleize.s %></a></h6>
+           </div>
+           <div id="collapsePassageTranslations" class="panel-collapse collapse">
+             <div class="panel-body">
+               <%=       highlighted_new_item_link [object, :passage_translation] %>
+               <%= render :partial => 'admin/passage_translations/list', :locals => { :list => object.passage_translations } %>
+           </div> <!-- END panel-body -->
+         </div> <!-- END collapseTwo -->
+       </section> <!-- END passage translations panel -->
+       <section class="panel panel-default">
          <div class="panel-heading">
            <h6><a href="#collapseFour" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= DefinitionSubjectAssociation.model_name.human(count: :many).titleize.s %></a></h6>
          </div>

--- a/app/views/admin/etymologies/edit.html.erb
+++ b/app/views/admin/etymologies/edit.html.erb
@@ -1,7 +1,7 @@
 <%
 if object.context.instance_of? Feature
   add_breadcrumb_item feature_link(object.feature)
-  add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s, admin_feature_path(object.feature, section: 'etymologies')
+  add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s, admin_feature_path(object.feature.fid, section: 'etymologies')
   add_breadcrumb_item link_to object.content.strip_tags.truncate(25).s, polymorphic_path([:admin, object.feature], section: 'etymologies')
 else
   add_breadcrumb_item feature_link(object.feature)

--- a/app/views/admin/etymologies/edit.html.erb
+++ b/app/views/admin/etymologies/edit.html.erb
@@ -1,13 +1,16 @@
 <%
 if object.context.instance_of? Feature
-  add_breadcrumb_item feature_link(object.feature, section: 'etymologies')
+  add_breadcrumb_item feature_link(object.feature)
+  add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s, admin_feature_path(object.feature, section: 'etymologies')
+  add_breadcrumb_item link_to object.content.strip_tags.truncate(25).s, polymorphic_path([:admin, object.feature], section: 'etymologies')
 else
   add_breadcrumb_item feature_link(object.feature)
   add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature], section: 'definitions')
   add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25).s, polymorphic_path([:admin, object.feature, object.context])
   add_breadcrumb_item link_to Etymology.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'etymologies')
+  add_breadcrumb_item link_to object.content.strip_tags.truncate(25).s, polymorphic_path([:admin, object.feature, object.context ], section: 'etymologies')
 end
-add_breadcrumb_item link_to object.content.strip_tags.truncate(25).s, polymorphic_path([:admin, object.feature, object.context ], section: 'etymologies') 
+ 
 add_breadcrumb_item ts 'edit.this'
 %>
 <section class="panel panel-content">

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -95,6 +95,7 @@
             <br class="clear"/>Other Dictionaries
           </legend>
 <%=       render partial: 'admin/definitions/list_legacy', locals: { list: object.definitions.legacy_definitions_by_info_source } %>
+<%=       render partial: 'admin/definitions/list_in_house', locals: { list: object.definitions.in_house_definitions_by_info_source } unless object.definitions.in_house_definitions_by_info_source.empty? %>
 <%=       association_note_list_fieldset(Definition.name) %>
         </div> <!-- END panel-body -->
       </div> <!-- END collapseTen -->

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -1,4 +1,4 @@
-<% add_breadcrumb_items object.fid %>
+<% add_breadcrumb_item feature_link(object) %>
 <div>
   <h1><%= ts :for, what: t(:entry), whom: object.name %></h1>
 </div>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -95,7 +95,7 @@
             <br class="clear"/>Other Dictionaries
           </legend>
 <%=       render partial: 'admin/definitions/list_legacy', locals: { list: object.definitions.legacy_definitions_by_info_source } %>
-<%=       association_note_list_fieldset(Description.name) %>
+<%=       association_note_list_fieldset(Definition.name) %>
         </div> <!-- END panel-body -->
       </div> <!-- END collapseTen -->
     </section>

--- a/app/views/admin/passage_translations/_form_fields.html.erb
+++ b/app/views/admin/passage_translations/_form_fields.html.erb
@@ -1,0 +1,24 @@
+<%= tinymce_assets %>
+<%= tinymce %>
+<% if object.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(object.errors.count, "error") %> prohibited this passage translation from being saved:</h2>
+
+      <ul>
+        <% object.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+<% end %>
+<fieldset>
+  <legend><%= ts(:for, what: t('information.general'), whom: PassageTranslation.model_name.human.titleize) %></legend>
+
+  <div class="row">
+    <%= form.label(:content).s %>
+  </div>
+  <div class="row">
+    <%= form.text_area :content, rows: 4, class: 'tinymce' %>
+  </div>
+
+</fieldset>

--- a/app/views/admin/passage_translations/_form_fields.html.erb
+++ b/app/views/admin/passage_translations/_form_fields.html.erb
@@ -20,5 +20,11 @@
   <div class="row">
     <%= form.text_area :content, rows: 4, class: 'tinymce' %>
   </div>
+  <div class="row">
+    <%= form.label :language_id, Language.model_name.human.titleize.s %>
+  </div>
+  <div class="row">
+  <%= form.collection_select :language_id, @languages, :id, :to_s, {include_blank: false}, class: 'form-control form-select ss-select selectpicker' %>
+  </div>
 
 </fieldset>

--- a/app/views/admin/passage_translations/_list.html.erb
+++ b/app/views/admin/passage_translations/_list.html.erb
@@ -13,9 +13,9 @@
      <tr>
        <td class="centerText">
          <%= list_actions_for_item(item, 
-            delete_path: admin_definition_passage_translation_path(item.context, item),
-            edit_path: edit_admin_definition_passage_translation_path(item.context, item), 
-            view_path: admin_definition_passage_translation_path(item.context, item)) 
+            delete_path: polymorphic_path([:admin, item.context, item]),
+            edit_path: edit_polymorphic_path([:admin, item.context, item]), 
+            view_path: polymorphic_path([:admin, item.context, item])) 
         %>
        </td>
        <td><%= item.language.name %></td>

--- a/app/views/admin/passage_translations/_list.html.erb
+++ b/app/views/admin/passage_translations/_list.html.erb
@@ -1,0 +1,28 @@
+<% if list.empty? %>
+  <%=  empty_collection_message("No #{PassageTranslation.model_name.human(count: :many).s} found.") %>
+<% end %>
+
+   <table class="listGrid">
+     <tr>
+       <th class="listActionsCol"></th>
+       <th><%= Language.model_name.human.titleize.s %></th>
+       <th><%= PassageTranslation.model_name.human.titleize.s %></th>
+       <th><%= Citation.model_name.human(count: :many).titleize.s %></th>
+     </tr>
+
+<% list.each do |item| %>
+     <tr>
+       <td class="centerText">
+         <%= list_actions_for_item(item, 
+            delete_path: admin_definition_passage_translation_path(item.context, item),
+            edit_path: edit_admin_definition_passage_translation_path(item.context, item), 
+            view_path: admin_definition_passage_translation_path(item.context, item)) 
+        %>
+       </td>
+       <td><%= item.language.name %></td>
+       <td><%= item.content.strip_tags.truncate(300).s %></td>
+       <td></td>
+     </tr>
+<% end %>
+   </table>
+

--- a/app/views/admin/passage_translations/_list.html.erb
+++ b/app/views/admin/passage_translations/_list.html.erb
@@ -1,8 +1,7 @@
 <% if list.empty? %>
   <%=  empty_collection_message("No #{PassageTranslation.model_name.human(count: :many).s} found.") %>
-<% end %>
-
-   <table class="listGrid">
+<% else %>
+  <table class="listGrid">
      <tr>
        <th class="listActionsCol"></th>
        <th><%= Language.model_name.human.titleize.s %></th>
@@ -10,7 +9,7 @@
        <th><%= Citation.model_name.human(count: :many).titleize.s %></th>
      </tr>
 
-<% list.each do |item| %>
+  <% list.each do |item| %>
      <tr>
        <td class="centerText">
          <%= list_actions_for_item(item, 
@@ -23,6 +22,7 @@
        <td><%= item.content.strip_tags.truncate(300).s %></td>
        <td></td>
      </tr>
+  <% end %>
+  </table>
 <% end %>
-   </table>
 

--- a/app/views/admin/passage_translations/edit.html.erb
+++ b/app/views/admin/passage_translations/edit.html.erb
@@ -1,13 +1,10 @@
 <%
-if object.context.instance_of? Feature
-  feature = object.context
-  add_breadcrumb_item feature_link(feature)
-  add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, admin_feature_path(feature.fid, section: 'passages')
-elsif object.context.instance_of? Definition
-  add_breadcrumb_item feature_link(object.context.feature)
+add_breadcrumb_item feature_link(object.context.feature)
+
+if object.context.instance_of? Definition
   add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
-  add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'passages')
-  add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'passages')
+  add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context], section: 'passage_translations')
+  add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
 end
 add_breadcrumb_item ts('edit.this')
 %>

--- a/app/views/admin/passage_translations/edit.html.erb
+++ b/app/views/admin/passage_translations/edit.html.erb
@@ -1,11 +1,28 @@
 <%
-add_breadcrumb_item feature_link(object.context.feature)
+  # can belong to a definition or a passage
+  # feature > definition > passage_translation
+  # feature > definition > passage > passage_translation
+  # feature > passage > passage_translation
+  #
+  add_breadcrumb_item feature_link(object.context.feature)
 
-if object.context.instance_of? Definition
-  add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
-  add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context], section: 'passage_translations')
-  add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
-end
+  if object.context.instance_of? Definition
+    add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
+    # higgins definitions are blank, so output the id in the breadcrumbs instead of the content
+    add_breadcrumb_item link_to object.context.content.strip_tags.blank? ? object.context.id : object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context])
+  end
+
+  if object.context.instance_of? Passage
+    if object.context.context.instance_of? Definition
+      add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.context.feature], section: 'definitions')
+      add_breadcrumb_item link_to object.context.context.content.strip_tags.blank? ? object.context.context.id : object.context.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context.context])
+    end
+
+    add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
+    add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25), polymorphic_path([:admin, object.context], section: 'passages')
+  end
+  
+  add_breadcrumb_item link_to PassageTranslation.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature, object.context], section: 'passage_translations')
 add_breadcrumb_item ts('edit.this')
 %>
 <section class="panel panel-content">

--- a/app/views/admin/passage_translations/edit.html.erb
+++ b/app/views/admin/passage_translations/edit.html.erb
@@ -1,0 +1,30 @@
+<%
+if object.context.instance_of? Feature
+  feature = object.context
+  add_breadcrumb_item feature_link(feature)
+  add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, admin_feature_path(feature.fid, section: 'passages')
+elsif object.context.instance_of? Definition
+  add_breadcrumb_item feature_link(object.context.feature)
+  add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
+  add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'passages')
+  add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'passages')
+end
+add_breadcrumb_item ts('edit.this')
+%>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6>Editing <%= PassageTranslation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+<%= form_with(model: [:admin, object.context, object], local: true) do |form| %>
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <% if object.context.instance_of? Feature %>
+        <%=  link_to ts('cancel.this'), admin_feature_path(feature.fid, section: 'passages'), class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% else %>
+        <%=  link_to ts('cancel.this'), polymorphic_path([:admin, object.context.feature,  object.context], section: 'passages'), class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% end %>
+      <%=  globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
+<% end %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->
+

--- a/app/views/admin/passage_translations/new.html.erb
+++ b/app/views/admin/passage_translations/new.html.erb
@@ -1,12 +1,27 @@
 <%
+  # can belong to a definition or a passage
+  # feature > definition > passage_translation
+  # feature > definition > passage > passage_translation
+  # feature > passage > passage_translation
+  #
   add_breadcrumb_item feature_link(object.context.feature)
-add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
+
   if object.context.instance_of? Definition
+    add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
     # higgins definitions are blank, so output the id in the breadcrumbs instead of the content
     add_breadcrumb_item link_to object.context.content.strip_tags.blank? ? object.context.id : object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context])
-  elsif object.context.instance_of? Passage
-    add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
   end
+
+  if object.context.instance_of? Passage
+    if object.context.context.instance_of? Definition
+      add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.context.feature], section: 'definitions')
+      add_breadcrumb_item link_to object.context.context.content.strip_tags.blank? ? object.context.context.id : object.context.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context.context])
+    end
+
+    add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
+    add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25), polymorphic_path([:admin, object.context], section: 'passages')
+  end
+  
   add_breadcrumb_item link_to PassageTranslation.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature, object.context], section: 'passage_translations')
 add_breadcrumb_item ts('new.this')
 %>

--- a/app/views/admin/passage_translations/new.html.erb
+++ b/app/views/admin/passage_translations/new.html.erb
@@ -1,0 +1,31 @@
+<%
+  add_breadcrumb_item feature_link(object.context.feature)
+add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
+  if object.context.instance_of? Definition
+    # higgins definitions are blank, so output the id in the breadcrumbs instead of the content
+    add_breadcrumb_item link_to object.context.content.strip_tags.blank? ? object.context.id : object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context])
+  elsif object.context.instance_of? Passage
+    add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
+  end
+  add_breadcrumb_item link_to PassageTranslation.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature, object.context], section: 'passage_translations')
+add_breadcrumb_item ts('new.this')
+%>
+<div>
+  <h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: PassageTranslation.model_name.human.titleize)), whom: "#{object.context.model_name.human.titleize} #{object.context}" %></h1>
+</div>
+<%= form_with(model: [:admin, object.context, object], local: true) do |form| %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6><%= PassageTranslation.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <% if object.context.instance_of? Feature %>
+        <%=  link_to ts('cancel.this'), admin_feature_path(feature.fid, section: 'passages') , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% else %>
+        <%=  link_to ts('cancel.this'), polymorphic_path([:admin, object.context.feature, object.context], section: 'passage_translations') , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <% end %>
+      <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->
+<% end %>

--- a/app/views/admin/passage_translations/show.html.erb
+++ b/app/views/admin/passage_translations/show.html.erb
@@ -1,0 +1,46 @@
+<%
+  add_breadcrumb_item feature_link(object.context.feature)
+add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
+  if object.context.instance_of? Definition
+    # higgins definitions are blank, so output the id in the breadcrumbs instead of the content
+    add_breadcrumb_item link_to object.context.content.strip_tags.blank? ? object.context.id : object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context])
+  elsif object.context.instance_of? Passage
+    add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
+  end
+  add_breadcrumb_item object.content.strip_tags.truncate(25).s
+%>
+ <section class="panel panel-content">
+   <div class="panel-heading">
+     <h6><%= PassageTranslation.model_name.human.titleize.s %></h6>
+   </div>
+   <div class="panel-body">
+     <div>
+       <h1><%= PassageTranslation.model_name.human.titleize.s %>:</h1>
+       <p>
+       <%= object.content.s %>
+       </p>
+     </div>
+     <br class="clear"/>
+     <div id="accordion" class="panel-group">
+       <section class="panel panel-default">
+           <div class="panel-heading">
+             <h6><a href="#collapseCitations" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Citation.model_name.human(count: :many).titleize.s %></a></h6>
+           </div>
+           <div id="collapseCitations" class="panel-collapse collapse">
+             <div class="panel-body">
+       <%= citation_list_fieldset %>
+           </div> <!-- END panel-body -->
+         </div> <!-- END collapseTwo -->
+       </section> <!-- END panel -->
+       
+     </div> <!-- END accordion -->
+
+     <%= link_to ts('edit.this'), polymorphic_path([:admin, object.context, object], {action: :edit}), class: 'btn btn-primary form-submit' %> |
+     <% if object.context.instance_of? Feature %>
+       <%= link_to ts('cancel.this'), admin_feature_path(object.context.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+     <% else %>
+       <%= link_to ts('cancel.this'), polymorphic_path([:admin, object.context.feature, object.context]), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+     <% end %>
+   </div> <!-- END panel-body -->
+ </section> <!-- END panel -->
+

--- a/app/views/admin/passage_translations/show.html.erb
+++ b/app/views/admin/passage_translations/show.html.erb
@@ -1,12 +1,27 @@
 <%
+  # can belong to a definition or a passage
+  # feature > definition > passage_translation
+  # feature > definition > passage > passage_translation
+  # feature > passage > passage_translation
+  #
   add_breadcrumb_item feature_link(object.context.feature)
-add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
+
   if object.context.instance_of? Definition
+    add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
     # higgins definitions are blank, so output the id in the breadcrumbs instead of the content
     add_breadcrumb_item link_to object.context.content.strip_tags.blank? ? object.context.id : object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context])
-  elsif object.context.instance_of? Passage
-    add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
   end
+
+  if object.context.instance_of? Passage
+    if object.context.context.instance_of? Definition
+      add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.context.feature], section: 'definitions')
+      add_breadcrumb_item link_to object.context.context.content.strip_tags.blank? ? object.context.context.id : object.context.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.context.context])
+    end
+
+    add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
+    add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25), polymorphic_path([:admin, object.context], section: 'passages')
+  end
+  
   add_breadcrumb_item link_to PassageTranslation.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature, object.context], section: 'passage_translations')
   add_breadcrumb_item object.content.strip_tags.truncate(25).s
 %>

--- a/app/views/admin/passage_translations/show.html.erb
+++ b/app/views/admin/passage_translations/show.html.erb
@@ -7,6 +7,7 @@ add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s
   elsif object.context.instance_of? Passage
     add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context], section: 'passages')
   end
+  add_breadcrumb_item link_to PassageTranslation.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature, object.context], section: 'passage_translations')
   add_breadcrumb_item object.content.strip_tags.truncate(25).s
 %>
  <section class="panel panel-content">

--- a/app/views/admin/passages/show.html.erb
+++ b/app/views/admin/passages/show.html.erb
@@ -28,10 +28,20 @@ add_breadcrumb_item object.content.strip_tags.truncate(25).s
            </div>
            <div id="collapseCitations" class="panel-collapse collapse">
              <div class="panel-body">
-       <%= citation_list_fieldset %>
+       <% #= citation_list_fieldset %>
            </div> <!-- END panel-body -->
          </div> <!-- END collapseTwo -->
        </section> <!-- END panel -->
+       <section class="panel panel-default">
+           <div class="panel-heading">
+             <h6><a href="#collapsePassageTranslations" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= PassageTranslation.model_name.human.titleize.s %></a></h6>
+           </div>
+           <div id="collapsePassageTranslations" class="panel-collapse collapse">
+             <div class="panel-body">
+       <%= "list passage translation here" %>
+           </div> <!-- END panel-body -->
+         </div> <!-- END collapseTwo -->
+       </section> <!-- END passage translations panel -->
      </div> <!-- END accordion -->
 
      <%= link_to ts('edit.this'), polymorphic_path([:admin, object.context, object], {action: :edit}), class: 'btn btn-primary form-submit' %> |

--- a/app/views/admin/passages/show.html.erb
+++ b/app/views/admin/passages/show.html.erb
@@ -4,7 +4,8 @@ if object.context.instance_of? Feature
 elsif object.context.instance_of? Definition
   add_breadcrumb_item feature_link(object.context.feature)
   add_breadcrumb_item link_to Definition.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.context.feature], section: 'definitions')
-  add_breadcrumb_item link_to object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'passages')
+  # higgins definitions are blank, so output the id in the breadcrumbs instead of the content
+  add_breadcrumb_item link_to object.context.content.strip_tags.blank? ? object.context.id : object.context.content.strip_tags.truncate(25).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'passages')
   add_breadcrumb_item link_to Passage.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.context], section: 'passages')
 end
 add_breadcrumb_item object.content.strip_tags.truncate(25).s
@@ -28,20 +29,11 @@ add_breadcrumb_item object.content.strip_tags.truncate(25).s
            </div>
            <div id="collapseCitations" class="panel-collapse collapse">
              <div class="panel-body">
-       <% #= citation_list_fieldset %>
+       <%= citation_list_fieldset %>
            </div> <!-- END panel-body -->
          </div> <!-- END collapseTwo -->
        </section> <!-- END panel -->
-       <section class="panel panel-default">
-           <div class="panel-heading">
-             <h6><a href="#collapsePassageTranslations" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= PassageTranslation.model_name.human.titleize.s %></a></h6>
-           </div>
-           <div id="collapsePassageTranslations" class="panel-collapse collapse">
-             <div class="panel-body">
-       <%= "list passage translation here" %>
-           </div> <!-- END panel-body -->
-         </div> <!-- END collapseTwo -->
-       </section> <!-- END passage translations panel -->
+       
      </div> <!-- END accordion -->
 
      <%= link_to ts('edit.this'), polymorphic_path([:admin, object.context, object], {action: :edit}), class: 'btn btn-primary form-submit' %> |

--- a/app/views/admin/passages/show.html.erb
+++ b/app/views/admin/passages/show.html.erb
@@ -50,9 +50,9 @@ add_breadcrumb_item object.content.strip_tags.truncate(25).s
 
      <%= link_to ts('edit.this'), polymorphic_path([:admin, object.context, object], {action: :edit}), class: 'btn btn-primary form-submit' %> |
      <% if object.context.instance_of? Feature %>
-       <%= link_to ts('cancel.this'), admin_feature_path(object.context.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+       <%= link_to ts('cancel.this'), admin_feature_path(object.context.fid, section: 'passages'), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% else %>
-       <%= link_to ts('cancel.this'), polymorphic_path([:admin, object.context.feature, object.context]), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+       <%= link_to ts('cancel.this'), polymorphic_path([:admin, object.context.feature, object.context], section: 'passages'), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
      <% end %>
    </div> <!-- END panel-body -->
  </section> <!-- END panel -->

--- a/app/views/admin/passages/show.html.erb
+++ b/app/views/admin/passages/show.html.erb
@@ -11,6 +11,7 @@ elsif object.context.instance_of? Definition
 end
 add_breadcrumb_item object.content.strip_tags.truncate(25).s
 %>
+<div id="passageShow" style="position:relative;">
  <section class="panel panel-content">
    <div class="panel-heading">
      <h6><%= Passage.model_name.human.titleize.s %></h6>
@@ -56,3 +57,5 @@ add_breadcrumb_item object.content.strip_tags.truncate(25).s
      <% end %>
    </div> <!-- END panel-body -->
  </section> <!-- END panel -->
+</div>
+<%= javascript_include_tag "terms_engine/passages_admin_accordion.js" %>

--- a/app/views/admin/passages/show.html.erb
+++ b/app/views/admin/passages/show.html.erb
@@ -1,4 +1,5 @@
 <%
+    # passage can belong to a feature or a definition
 if object.context.instance_of? Feature
   add_breadcrumb_item feature_link(object.context)
 elsif object.context.instance_of? Definition
@@ -33,7 +34,18 @@ add_breadcrumb_item object.content.strip_tags.truncate(25).s
            </div> <!-- END panel-body -->
          </div> <!-- END collapseTwo -->
        </section> <!-- END panel -->
-       
+       <section class="panel panel-default">
+           <div class="panel-heading">
+             <h6><a href="#collapsePassageTranslations" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= PassageTranslation.model_name.human(count: :many).titleize.s %></a></h6>
+           </div>
+           <div id="collapsePassageTranslations" class="panel-collapse collapse">
+             <div class="panel-body">
+               <%=       highlighted_new_item_link [object, :passage_translation] %>
+               <br class="clear" />
+               <%= render :partial => 'admin/passage_translations/list', :locals => { :list => object.passage_translations } %>
+           </div> <!-- END panel-body -->
+         </div> <!-- END collapseTwo -->
+       </section> <!-- END passage translations panel --> 
      </div> <!-- END accordion -->
 
      <%= link_to ts('edit.this'), polymorphic_path([:admin, object.context, object], {action: :edit}), class: 'btn btn-primary form-submit' %> |

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,5 +12,6 @@ Rails.application.config.assets.precompile.concat(['terms_engine/recordings.js',
                                                    'terms_engine/related-section-initializer.js',
                                                    'terms_engine/features_admin_accordion.js',
                                                    'terms_engine/definitions_admin_accordion.js',
+                                                   'terms_engine/passages_admin_accordion.js',
                                                    'terms_engine/feature_names_admin_accordion.js'
                                                    ])

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -54,6 +54,12 @@ bo:
             model_sentence:
                 one: 'model sentence'
                 other: 'model sentences'
+            passage:
+                one: 'passage'
+                other: 'passages'
+            passage_translation:
+                one: 'passage translation'
+                other: 'passage translations'
             recording:
                 one: 'recording'
                 other: 'recordings'

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -42,16 +42,16 @@ bo:
         search: 'Use the search field above to search for terms.'
     accordion:
         caption:
-            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+            help_text: 'Captions describe the term in 140 or fewer characters, including spaces. They appear in term previews around Mandala.'
         definition_etymology:
             help_text: 'An etymology can be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is for creating etymologies specific to one definition of a term. To instead add an etymology for the entire term, regardless of definitions, go to the Etymology module at the root level of the editing interface (not the Definitions module in which you are currently), and you can do so there.'
         etymology:
             help_text: 'An etymology can  be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is specifically for creating etymologies pertaining to the entire term. To instead add an etymology limited to just one specific definition of the term, go to the Definitions module and there click on the magnifying glass for the definition in question, which can then be modified.'
         feature_geo_code:
-            help_text: 'Other dictionary ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Other dictionary IDs are identifiers for the term as found in external print or digital publication. For example, the Wikidata entity ID. Contact THL if you want to add a new type of other dictionary ID to the options.'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
-            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+            help_text: 'Recordings let you add audio files of the term being spoken. Accepted file formats: [file formats TBD ]'
         summary:
-            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'
+            help_text: 'Summaries describe the term in 750 or fewer characters, including spaces. They appear on the overview page for the term.'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -54,6 +54,12 @@ dz:
             model_sentence:
                 one: 'model sentence'
                 other: 'model sentences'
+            passage:
+                one: 'passage'
+                other: 'passages'
+            passage_translation:
+                one: 'passage translation'
+                other: 'passage translations'
             recording:
                 one: 'recording'
                 other: 'recordings'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -42,16 +42,16 @@ dz:
         search: 'Use the search field above to search for terms.'
     accordion:
         caption:
-            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+            help_text: 'Captions describe the term in 140 or fewer characters, including spaces. They appear in term previews around Mandala.'
         definition_etymology:
             help_text: 'An etymology can be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is for creating etymologies specific to one definition of a term. To instead add an etymology for the entire term, regardless of definitions, go to the Etymology module at the root level of the editing interface (not the Definitions module in which you are currently), and you can do so there.'
         etymology:
             help_text: 'An etymology can  be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is specifically for creating etymologies pertaining to the entire term. To instead add an etymology limited to just one specific definition of the term, go to the Definitions module and there click on the magnifying glass for the definition in question, which can then be modified.'
         feature_geo_code:
-            help_text: 'Other dictionary ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Other dictionary IDs are identifiers for the term as found in external print or digital publication. For example, the Wikidata entity ID. Contact THL if you want to add a new type of other dictionary ID to the options.'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
-            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+            help_text: 'Recordings let you add audio files of the term being spoken. Accepted file formats: [file formats TBD ]'
         summary:
-            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'
+            help_text: 'Summaries describe the term in 750 or fewer characters, including spaces. They appear on the overview page for the term.'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -57,6 +57,9 @@ en:
             passage:
                 one: 'passage'
                 other: 'passages'
+            passage_translation:
+                one: 'passage translation'
+                other: 'passage translations'
             recording:
                 one: 'recording'
                 other: 'recordings'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -42,16 +42,16 @@ en:
         search: 'Use the search field above to search for terms.'
     accordion:
         caption:
-            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+            help_text: 'Captions describe the term in 140 or fewer characters, including spaces. They appear in term previews around Mandala.'
         definition_etymology:
             help_text: 'An etymology can be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is for creating etymologies specific to one definition of a term. To instead add an etymology for the entire term, regardless of definitions, go to the Etymology module at the root level of the editing interface (not the Definitions module in which you are currently), and you can do so there.'
         etymology:
             help_text: 'An etymology can  be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is specifically for creating etymologies pertaining to the entire term. To instead add an etymology limited to just one specific definition of the term, go to the Definitions module and there click on the magnifying glass for the definition in question, which can then be modified.'
         feature_geo_code:
-            help_text: 'Other dictionary ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Other dictionary IDs are identifiers for the term as found in external print or digital publication. For example, the Wikidata entity ID. Contact THL if you want to add a new type of other dictionary ID to the options.'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
-            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+            help_text: 'Recordings let you add audio files of the term being spoken. Accepted file formats: [file formats TBD ]'
         summary:
-            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'
+            help_text: 'Summaries describe the term in 750 or fewer characters, including spaces. They appear on the overview page for the term.'

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -57,6 +57,12 @@ zh:
             model_sentence:
                 one: 'model sentence'
                 other: 'model sentences'
+            passage:
+                one: 'passage'
+                other: 'passages'
+            passage_translation:
+                one: 'passage translation'
+                other: 'passage translations'
             recording:
                 one: 'recording'
                 other: 'recordings'

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -42,16 +42,16 @@ zh:
         search: 'Use the search field above to search for terms.'
     accordion:
         caption:
-            help_text: 'Captions describe the term in fewer than 140 characters, including spaces. They appear in term previews around Mandala.'
+            help_text: 'Captions describe the term in 140 or fewer characters, including spaces. They appear in term previews around Mandala.'
         definition_etymology:
             help_text: 'An etymology can be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is for creating etymologies specific to one definition of a term. To instead add an etymology for the entire term, regardless of definitions, go to the Etymology module at the root level of the editing interface (not the Definitions module in which you are currently), and you can do so there.'
         etymology:
             help_text: 'An etymology can  be a basic explanation of each syllable’s meaning, a linguistic historical etymology, or a creative-interpretative etymology. The current interface is specifically for creating etymologies pertaining to the entire term. To instead add an etymology limited to just one specific definition of the term, go to the Definitions module and there click on the magnifying glass for the definition in question, which can then be modified.'
         feature_geo_code:
-            help_text: 'Other dictionary ids are identifiers for the term as found in external print or digital publications. For example, the Wikidata entity ID. Contact THL if you want to add a new type of term code to the options.'
+            help_text: 'Other dictionary IDs are identifiers for the term as found in external print or digital publication. For example, the Wikidata entity ID. Contact THL if you want to add a new type of other dictionary ID to the options.'
         illustration:
             help_text: "Featured images appear on the main overview page for the term. Add image files to Mandala Images first. For help, please see %{link}."
         recording:
-            help_text: 'Recordings let you add audio files of your term being spoken. Accepted files formats: mp3'
+            help_text: 'Recordings let you add audio files of the term being spoken. Accepted file formats: [file formats TBD ]'
         summary:
-            help_text: 'Summaries describe the term in fewer than 750 characters, including spaces. They appear on the overview page for the term.'
+            help_text: 'Summaries describe the term in 750 or fewer characters, including spaces. They appear on the overview page for the term.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
       resources :etymologies, :passages, :recordings, :subject_term_associations
     end
     resources :passages, only: [:show] do
-      resources :citations
+      resources :citations, :passage_translations
     end
     resources :passage_translations, only: [:show] do
       resources :citations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,10 +14,10 @@ Rails.application.routes.draw do
       post :prioritize, on: :collection, to: 'info_sources#set_priorities'
     end
     resources :definitions do
-      resources :citations, :etymologies, :definition_relations, :definition_subject_associations, :passage_translations
-      resources :passages do
-        resources :passage_translations
-      end
+      resources :citations, :etymologies, :definition_relations, :definition_subject_associations, :passages, :passage_translations
+      #resources :passages do
+      #  resources :passage_translations
+      #end
       resources :definition_associations, except: [:new, :index]
     end
     resources :etymologies do
@@ -32,7 +32,10 @@ Rails.application.routes.draw do
       resources :etymologies, :passages, :recordings, :subject_term_associations
     end
     resources :passages, only: [:show] do
-      resources :citations, :passage_translations
+      resources :citations
+    end
+    resources :passages do
+      resources :passage_translations
     end
     resources :passage_translations, only: [:show] do
       resources :citations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
       post :prioritize, on: :collection, to: 'info_sources#set_priorities'
     end
     resources :definitions do
-      resources :citations, :etymologies, :definition_relations, :definition_subject_associations, :passages
+      resources :citations, :etymologies, :definition_relations, :definition_subject_associations, :passages, :passage_translations
       resources :definition_associations, except: [:new, :index]
     end
     resources :etymologies do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,9 @@ Rails.application.routes.draw do
     resources :passages, only: [:show] do
       resources :citations
     end
+    resources :passage_translations, only: [:show] do
+      resources :citations
+    end
   end
   resources :definitions, concerns: :notable_citable, only: ['show', 'index']
   resources :definition_associations, concerns: :notable_citable, only: ['show', 'index']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,10 @@ Rails.application.routes.draw do
       post :prioritize, on: :collection, to: 'info_sources#set_priorities'
     end
     resources :definitions do
-      resources :citations, :etymologies, :definition_relations, :definition_subject_associations, :passages, :passage_translations
+      resources :citations, :etymologies, :definition_relations, :definition_subject_associations, :passage_translations
+      resources :passages do
+        resources :passage_translations
+      end
       resources :definition_associations, except: [:new, :index]
     end
     resources :etymologies do


### PR DESCRIPTION
**MANU-7873:** [https://uvaissues.atlassian.net/browse/MANU-7873]
**MANU-7891:** [https://uvaissues.atlassian.net/browse/MANU-7891]
**MANU-7917:** [https://uvaissues.atlassian.net/browse/MANU-7917]
**MANU-7786:** [https://uvaissues.atlassian.net/browse/MANU-7786]
**Changes proposed in this pull request:**

 + continue updating breadcrumb functionality to be clearer; fix bug introduced in last changes for etymologies crumbs
 + redirect form submissions to appropriate page/accordion section wip; done for etymology subject assoc. and passage translations
 + making passage translations editable, which necessitates displaying "in house definitions" (they were not shown before, which meant that passages and passage translations that were children of these definitions were not accessible in admin) for the Higgins dictionary
+ revise accordion section help texts based on feedback from team


