### PR TITLE
Feature/several

### DIFF
--- a/app/helpers/extended_admin_helper.rb
+++ b/app/helpers/extended_admin_helper.rb
@@ -19,7 +19,7 @@ module ExtendedAdminHelper
     if !parent_object.instance_of?(Feature)
       if parent_object.instance_of?(FeatureNameRelation)
         array << parent_object.child_node
-      elsif parent_object.instance_of?(Passage)
+      elsif parent_object.instance_of?(Passage) || parent_object.instance_of?(PassageTranslation)
         array << parent_object.context
       elsif parent_object.respond_to?(:feature)
         array << parent_object.feature

--- a/app/models/passage_translation.rb
+++ b/app/models/passage_translation.rb
@@ -9,7 +9,7 @@
 #  updated_at   :datetime         not null
 #  context_id   :bigint           not null
 #  language_id  :integer          not null
-#
+# 
 # Indexes
 #
 #  index_passage_translations_on_context_type_and_context_id  (context_type,context_id)
@@ -18,8 +18,12 @@ class PassageTranslation < ApplicationRecord
   include KmapsEngine::IsCitable
   include KmapsEngine::IsNotable
   
-  belongs_to :context, polymorphic: true
+  belongs_to :context, polymorphic: true, touch: true
   belongs_to :language
+  
+  def feature
+    self.context.feature
+  end
   
   def rsolr_document_tags(document, prefix = '')
     prefix_ = prefix.blank? ? '' : "#{prefix}_"
@@ -31,4 +35,5 @@ class PassageTranslation < ApplicationRecord
     document["#{passage_translation_prefix}_citation_references_ss"] = citation_references if !citation_references.blank?
     self.notes.each { |n| n.rsolr_document_tags(document, passage_translation_prefix) }
   end
+
 end

--- a/app/views/admin/definitions/_list_in_house.html.erb
+++ b/app/views/admin/definitions/_list_in_house.html.erb
@@ -17,6 +17,7 @@
          </td>
          <td><%= item.language.name %></td>
          <td><%= item.snippet.s %></td>
+         <td><%= accordion_citation_list_fieldset(object: item) %></td>
      </tr>
 <%     end
      end %>

--- a/app/views/admin/definitions/_list_legacy.html.erb
+++ b/app/views/admin/definitions/_list_legacy.html.erb
@@ -7,6 +7,7 @@
        <th class="listActionsCol"></th>
        <th><%= Language.model_name.human.titleize.s %></th>
        <th><%= Definition.model_name.human.titleize.s %></th>
+       <th><%= Citation.model_name.human(count: :many).titleize.s %></th>
      </tr>
 <%   list.each do |row|
        source = InfoSource.find(row.first)
@@ -25,6 +26,7 @@
          </td>
          <td><%= item.language.name %></td>
          <td><%= item.snippet.s %></td>
+         <td><%= accordion_citation_list_fieldset(object: item) %></td>
      </tr>
 <%     end
      end %>

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -140,11 +140,7 @@
       <div id="collapseTwelve" class="panel-collapse collapse">
         <div class="panel-body">
           <%=       highlighted_new_item_link [object, :subject_term_association], "New #{SubjectTermAssociation.model_name.human}" %>
-          <br>
-          <h6>Some common subject associations to start with:</h6>
-          <ul class="subject-term-associations-list">
-<%=       new_subject_term_associations_links object %>
-          </ul>
+          
           <br class="clear"/>
 <%=       render partial: 'admin/subject_term_associations/list', locals: { list: object.subject_term_associations } %>
         </div> <!-- END panel-body -->

--- a/app/views/admin/passage_translations/_list.html.erb
+++ b/app/views/admin/passage_translations/_list.html.erb
@@ -7,6 +7,7 @@
        <th><%= Language.model_name.human.titleize.s %></th>
        <th><%= PassageTranslation.model_name.human.titleize.s %></th>
        <th><%= Citation.model_name.human(count: :many).titleize.s %></th>
+       <th><%= Note.model_name.human(count: :many).titleize.s %></th>
      </tr>
 
   <% list.each do |item| %>
@@ -20,7 +21,8 @@
        </td>
        <td><%= item.language.name %></td>
        <td><%= item.content.strip_tags.truncate(300).s %></td>
-       <td></td>
+       <td><%= accordion_citation_list_fieldset(object: item) %></td>
+       <td>tbd notes</td>
      </tr>
   <% end %>
   </table>

--- a/app/views/admin/passages/_list.html.erb
+++ b/app/views/admin/passages/_list.html.erb
@@ -6,6 +6,7 @@
        <th class="listActionsCol"></th>
        <th><%= Passage.human_attribute_name('content').s %></th>
        <th><%= Citation.model_name.human(count: :many).titleize.s %></th>
+       <th><%= Note.model_name.human(count: :many).titleize.s %></th>
      </tr>
 <%   list.each do |item| %>
      <tr>
@@ -16,6 +17,7 @@
        </td>
        <td><%= item.content.s %></td>
        <td><%= accordion_citation_list_fieldset(object: item) %></td>
+       <td><%= "tbd notes" %></td>
      </tr>
 <%   end %>
    </table>

--- a/app/views/admin/passages/_list.html.erb
+++ b/app/views/admin/passages/_list.html.erb
@@ -17,7 +17,7 @@
        </td>
        <td><%= item.content.s %></td>
        <td><%= accordion_citation_list_fieldset(object: item) %></td>
-       <td><%= "tbd notes" %></td>
+       <td><%= accordion_note_list_fieldset(item) %></td>
      </tr>
 <%   end %>
    </table>

--- a/config/initializers/loaders.rb
+++ b/config/initializers/loaders.rb
@@ -57,3 +57,8 @@ ActiveSupport.on_load(:admin_feature_relation_types_controller) do
   require 'terms_engine/extensions/admin_feature_relation_types_controller'
   include TermsEngine::Extension::AdminFeatureRelationTypesController
 end
+
+ActiveSupport.on_load(:admin_notes_controller) do
+  require 'terms_engine/extensions/admin_notes_controller'
+  include TermsEngine::Extension::AdminNotesController
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   end
   resources :recordings, only: [:show]
   namespace :admin do
+    concern :add_author do
+      get :add_author, on: :collection
+    end
     resources :definition_relations
     resources :info_sources do
       get :prioritize, on: :collection, to: 'info_sources#prioritize'
@@ -33,6 +36,7 @@ Rails.application.routes.draw do
     end
     resources :passages, only: [:show] do
       resources :citations
+      resources :notes, concerns: :add_author
     end
     resources :passages do
       resources :passage_translations

--- a/lib/terms_engine/extensions/admin_citations_controller.rb
+++ b/lib/terms_engine/extensions/admin_citations_controller.rb
@@ -5,7 +5,7 @@ module TermsEngine
 
       included do
         belongs_to :caption, :description, :feature, :feature_geo_code, :feature_name, :feature_name_relation, :feature_relation, :summary, #This list comes from the CitationsController in kmaps_engine
-        :definition, :passage, :subject_term_association #specific to terms_engine
+        :definition, :passage, :subject_term_association, :passage_translation #specific to terms_engine
 
         create.wants.html  { redirect_to polymorphic_url(helpers.stacked_parents, section: 'citations') }
         update.wants.html  { redirect_to polymorphic_url(helpers.stacked_parents, section: 'citations') }

--- a/lib/terms_engine/extensions/admin_notes_controller.rb
+++ b/lib/terms_engine/extensions/admin_notes_controller.rb
@@ -1,0 +1,20 @@
+module TermsEngine
+  module Extension
+    module AdminNotesController
+
+      extend ActiveSupport::Concern
+
+      included do
+        belongs_to :description, :feature_geo_code, :feature_name, :feature_name_relation, :feature_relation, :time_unit, # from kmaps_engine
+        :definition, :etymology, :passage, :passage_translation, :subject_term_association #specific to terms_engine
+
+       
+        create.wants.html  { redirect_to polymorphic_url(helpers.stacked_parents, section: 'notes') }
+        update.wants.html  { redirect_to polymorphic_url(helpers.stacked_parents, section: 'notes') }
+        destroy.wants.html { redirect_to polymorphic_url(helpers.stacked_parents, section: 'notes') }
+
+      end
+      
+    end
+  end
+end


### PR DESCRIPTION
https://uvaissues.atlassian.net/browse/MANU-7792
* adds Notes interface to Passages
* adds Citations interface to Passage Translations

https://uvaissues.atlassian.net/browse/MANU-7917
* adds CRUD interface for Passage Translations
* bugfix for error introduced in last batch of work on Citations belonging to Passage Translations

https://uvaissues.atlassian.net/browse/MANU-7776
* adds Citations to the data tables under Definitions

https://uvaissues.atlassian.net/browse/MANU-7849
* incorporating feedback from review to remove the "Some common associations to start with" list of links from subject term associations interface

https://uvaissues.atlassian.net/browse/MANU-7891 
* Create an extended breadcrumb method in terms app; remove terms specific items from method in kmaps app and check for existence of extended breadcrumbs
