### PR TITLE
MANU-7891 fixes bug with removing HOME from breadcrumbs

### DIFF
--- a/app/assets/stylesheets/terms_engine/application.css
+++ b/app/assets/stylesheets/terms_engine/application.css
@@ -79,3 +79,8 @@ body.page-terms .main-col {
  /* box-shadow:none; */
 }
 /* END - fancytree */
+
+.breadcrumb li:first-child a {
+  display: none;
+}
+/* this hides the HOME item in the breadcrumbs for terms app only */


### PR DESCRIPTION
Removing with css in terms app only instead. 

**MANU-7929** https://uvaissues.atlassian.net/browse/MANU-7929
**MANU-7891** https://uvaissues.atlassian.net/browse/MANU-7891

Reverted the change that removed the HOME link from the breadcrumbs ordered list in the helper in kmaps_engine; 
we're hiding the HOME link via css in terms_engine instead. 

This change resulted from some css that clipped the output of the breadcrumbs first-child, causing the first link not to have the separator displayed. Rather than risk changing something that's applied to multiple apps, just going to add a line of CSS here.
