### PR TITLE
MANU-7939 add admin for NOTES to Passages, Passage Translations, Etymologies and Definitions

### DIFF
--- a/app/helpers/extended_admin_helper.rb
+++ b/app/helpers/extended_admin_helper.rb
@@ -46,7 +46,7 @@ module ExtendedAdminHelper
       end
     when :definition # in terms_engine
       add_breadcrumb_item link_to(Definition.model_name.human(:count => :many).s, admin_feature_path(object.feature.fid, section: 'definitions'))
-      add_breadcrumb_item link_to(parent_object.content.strip_tags.truncate(25).s, admin_feature_definition_path(object.feature, parent_object, section: 'citations'))
+      add_breadcrumb_item link_to( (parent_object.content.blank? ? parent_object.id : parent_object.content.strip_tags.truncate(25).s), admin_feature_definition_path(object.feature, parent_object, section: 'citations'))
     when :description
       add_breadcrumb_item feature_descriptions_link(parent_object.feature)
       add_breadcrumb_item link_to(parent_object.title.strip_tags.truncate(25).titleize.s, admin_feature_description_path(parent_object.feature, parent_object))

--- a/app/views/admin/definitions/show.html.erb
+++ b/app/views/admin/definitions/show.html.erb
@@ -111,6 +111,16 @@
          </div> <!-- END collapseTwo -->
        </section> <!-- END panel -->
        <section class="panel panel-default">
+        <div class="panel-heading">
+          <h6><a href="#collapseNotes" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= ts 'Notes' %></a></h6>
+        </div>
+        <div id="collapseNotes" class="panel-collapse collapse">
+          <div class="panel-body">
+            <%= note_list_fieldset %>
+          </div> <!-- END panel-body -->
+        </div> <!-- END collapseThree -->
+       </section> <!-- END panel NOTES -->
+       <section class="panel panel-default">
          <div class="panel-heading">
            <h6><a href="#collapsePassages" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Passage.model_name.human(:count => :many).titleize.s %></a></h6>
          </div>

--- a/app/views/admin/etymologies/show.html.erb
+++ b/app/views/admin/etymologies/show.html.erb
@@ -46,6 +46,16 @@ add_breadcrumb_item object.content.strip_tags.truncate(25).s
            </div> <!-- END panel-body -->
          </div> <!-- END collapseTen -->
        </section>
+       <section class="panel panel-default">
+        <div class="panel-heading">
+          <h6><a href="#collapseNotes" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= ts 'Notes' %></a></h6>
+        </div>
+        <div id="collapseNotes" class="panel-collapse collapse">
+          <div class="panel-body">
+            <%= note_list_fieldset %>
+          </div> <!-- END panel-body -->
+        </div> <!-- END collapseThree -->
+       </section> <!-- END panel NOTES -->
      </div> <!-- END accordion -->
 
      <%= link_to ts('edit.this'), polymorphic_path([:admin, object.context,object], {action: :edit}), class: 'btn btn-primary form-submit' %> |

--- a/app/views/admin/passage_translations/_list.html.erb
+++ b/app/views/admin/passage_translations/_list.html.erb
@@ -22,7 +22,7 @@
        <td><%= item.language.name %></td>
        <td><%= item.content.strip_tags.truncate(300).s %></td>
        <td><%= accordion_citation_list_fieldset(object: item) %></td>
-       <td>tbd notes</td>
+       <td><%= accordion_note_list_fieldset(item) %></td>
      </tr>
   <% end %>
   </table>

--- a/app/views/admin/passage_translations/show.html.erb
+++ b/app/views/admin/passage_translations/show.html.erb
@@ -48,7 +48,16 @@
            </div> <!-- END panel-body -->
          </div> <!-- END collapseTwo -->
        </section> <!-- END panel -->
-       
+       <section class="panel panel-default">
+        <div class="panel-heading">
+          <h6><a href="#collapseNotes" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= ts 'Notes' %></a></h6>
+          </div>
+        <div id="collapseNotes" class="panel-collapse collapse">
+          <div class="panel-body">
+            <%= note_list_fieldset %>
+          </div> <!-- END panel-body -->
+        </div> <!-- END collapseThree -->
+      </section> <!-- END panel NOTES --> 
      </div> <!-- END accordion -->
 
      <%= link_to ts('edit.this'), polymorphic_path([:admin, object.context, object], {action: :edit}), class: 'btn btn-primary form-submit' %> |

--- a/app/views/admin/passages/show.html.erb
+++ b/app/views/admin/passages/show.html.erb
@@ -36,6 +36,16 @@ add_breadcrumb_item object.content.strip_tags.truncate(25).s
          </div> <!-- END collapseTwo -->
        </section> <!-- END panel -->
        <section class="panel panel-default">
+        <div class="panel-heading">
+          <h6><a href="#collapseNotes" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= ts 'Notes' %></a></h6>
+        </div>
+        <div id="collapseNotes" class="panel-collapse collapse">
+          <div class="panel-body">
+            <%= note_list_fieldset %>
+          </div> <!-- END panel-body -->
+        </div> <!-- END collapseThree -->
+       </section> <!-- END panel NOTES -->
+       <section class="panel panel-default">
            <div class="panel-heading">
              <h6><a href="#collapsePassageTranslations" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= PassageTranslation.model_name.human(count: :many).titleize.s %></a></h6>
            </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
     end
     resources :passage_translations, only: [:show] do
       resources :citations
+      resources :notes, concerns: :add_author
     end
   end
   resources :definitions, concerns: :notable_citable, only: ['show', 'index']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     end
     resources :definitions do
       resources :citations, :etymologies, :definition_relations, :definition_subject_associations, :passages, :passage_translations
+      resources :notes, concerns: :add_author
       #resources :passages do
       #  resources :passage_translations
       #end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     end
     resources :etymologies do
       resources :etymology_type_associations, :etymology_subject_associations
+      resources :notes, concerns: :add_author
     end
     resources :features do
       post :create_tibetan_term, on: :collection
@@ -49,6 +50,7 @@ Rails.application.routes.draw do
   end
   resources :definitions, concerns: :notable_citable, only: ['show', 'index']
   resources :definition_associations, concerns: :notable_citable, only: ['show', 'index']
+  resources :etymologies, concerns: :notable_citable, only: ['show', 'index']
   resources :passages, concerns: :notable_citable, only: ['show', 'index']
   resources :passage_translations, concerns: :notable_citable, only: ['show', 'index']
   resources :translation_equivalents, concerns: :notable_citable, only: ['show', 'index']


### PR DESCRIPTION
https://uvaissues.atlassian.net/browse/MANU-7939

Adds admin functionality for NOTES to Passages, Passage Translations, Etymologies and Definitions.

- adds the routes for Definition notes
- adds the accordion tab to the aforementioned sections accordion pages
- tweaks the breadcrumbs for Definitions a wee bit to show the definition ID instead of content when content is blank