### PR TITLE
MANU-7297 fixes end user definition enumeration view

### DIFF
--- a/app/views/features/_definition.html.erb
+++ b/app/views/features/_definition.html.erb
@@ -75,7 +75,7 @@
 <%             end %>
 <%              unless definition.enumeration.nil? %>
                   <dt><%= Enumeration.model_name.human.s %>:</dt>
-                  <dd><%= enumeration.value %></dd>
+                  <dd><%= definition.enumeration.value %></dd>
 <%             end %>
              </dl>
            </div>


### PR DESCRIPTION
MANU-7297

Fixes bug where end user Feature (Term) view 500s out when a definition has an enumeration defined