### PR TITLE
Removes notes and enumerations  from definition relations list; def r…

### DIFF
--- a/app/views/admin/definition_relations/_list.html.erb
+++ b/app/views/admin/definition_relations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+  <%=  empty_collection_message %>
 <% else
      options ||= {} %>
      <table class="listGrid">
@@ -10,10 +10,7 @@
 <%=     "<th>#{ts 'relat.ed.to'}</th>".html_safe unless options[:hide_related_to] %>
          <th><%= Definition.human_attribute_name(:content).s %></th>
          <th><%= Definition.human_attribute_name(:author).s %></th>
-         <th><%= Enumeration.model_name.human.s %></th>
          <th><%= Definition.human_attribute_name(:tense).s %></th>
-         <th><%= Note.model_name.human(:count => :many).titleize.s %></th>
-         <th><%= ts 'add.record', :what => Note.model_name.human.titleize %></th>
        </tr>
 <%     list.each do |item| %>
        <tr>
@@ -31,13 +28,8 @@
            <%= def_if_blank item, :author, :fullname %>
          </td>
          <td>
-<%=       # def_if_blank(item, :numerology) { '' } %>
-         </td>
-         <td>
 <%=        def_if_blank(item, :tense) { '' } %>
          </td>
-         <td><%= note_link_list_for item %></td>
-         <td><%= new_note_link_for item %></td>
        </tr>
 <%     end %>
      </table>


### PR DESCRIPTION
MANU-7941 - the work in the PR doesn't actually do anything for that ticket;
Steve reported a bug that when two top level definitons are used to create a definition relation, the child definition is not shown with the other top level definitions anymore. This isan't actually a bug though.

What this branch does is fix a 500 error and remove Notes from definition relations display because definition relations don't have notes.
